### PR TITLE
MOB-244 Renamed Core Paystack module 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     products: [
         .library(
             name: "PaystackSDK",
-            targets: ["Paystack"]),
+            targets: ["PaystackSDK"]),
         .library(
             name: "PaystackSDK/Transactions",
             targets: ["Paystack/Transactions"]),
@@ -19,20 +19,20 @@ let package = Package(
     dependencies: [],
     targets: [
         .target(
-            name: "Paystack",
+            name: "PaystackSDK",
             dependencies: [],
             path: "Sources/PaystackSDK/Core"),
         .target(
             name: "Paystack/Transactions",
-            dependencies: ["Paystack"],
+            dependencies: ["PaystackSDK"],
             path: "Sources/PaystackSDK/API/Transactions"),
         .target(
             name: "Paystack/Checkout",
-            dependencies: ["Paystack"],
+            dependencies: ["PaystackSDK"],
             path: "Sources/PaystackSDK/API/Checkout"),
         .testTarget(
             name: "PaystackSDKTests",
-            dependencies: ["Paystack", "Paystack/Transactions", "Paystack/Checkout"],
+            dependencies: ["PaystackSDK", "Paystack/Transactions", "Paystack/Checkout"],
             resources: [
                 .copy("API/Transactions/Resources/VerifyAccessCode.json"),
                 .copy("API/Checkout/Resources/RequestInline.json")

--- a/Sources/PaystackSDK/API/Checkout/Checkout.swift
+++ b/Sources/PaystackSDK/API/Checkout/Checkout.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Paystack
+import PaystackSDK
 
 /// The Transactions API allows you create and manage payments on your integration.
 public extension Paystack {

--- a/Sources/PaystackSDK/API/Checkout/CheckoutService.swift
+++ b/Sources/PaystackSDK/API/Checkout/CheckoutService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Paystack
+import PaystackSDK
 
 protocol CheckoutService: PaystackService {
     func getRequestInline(_ queries: [RequestInlineQuery]) -> Service<TransactionResponse>

--- a/Sources/PaystackSDK/API/Checkout/Query/RequestInlineQuery.swift
+++ b/Sources/PaystackSDK/API/Checkout/Query/RequestInlineQuery.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Paystack
+import PaystackSDK
 
 public enum RequestInlineQuery {
     case email(String)

--- a/Sources/PaystackSDK/API/Transactions/TransactionService.swift
+++ b/Sources/PaystackSDK/API/Transactions/TransactionService.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Paystack
+import PaystackSDK
 
 protocol TransactionService: PaystackService {
     func getVerifyAccessCode(_ id: Int) -> Service<TransactionResponse>

--- a/Sources/PaystackSDK/API/Transactions/Transactions.swift
+++ b/Sources/PaystackSDK/API/Transactions/Transactions.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Paystack
+import PaystackSDK
 
 /// The Transactions API allows you create and manage payments on your integration.
 public extension Paystack {

--- a/Tests/PaystackSDKTests/API/Checkout/CheckoutTests.swift
+++ b/Tests/PaystackSDKTests/API/Checkout/CheckoutTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Paystack
+@testable import PaystackSDK
 
 @testable import Paystack_Checkout
 

--- a/Tests/PaystackSDKTests/API/Transactions/TransactionsTests.swift
+++ b/Tests/PaystackSDKTests/API/Transactions/TransactionsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Paystack
+@testable import PaystackSDK
 
 @testable import Paystack_Transactions
 

--- a/Tests/PaystackSDKTests/Common/MockServiceExecutor.swift
+++ b/Tests/PaystackSDKTests/Common/MockServiceExecutor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@testable import Paystack
+@testable import PaystackSDK
 
 class MockServiceExecutor: ServiceExecutor {
     

--- a/Tests/PaystackSDKTests/Common/PSTestCase.swift
+++ b/Tests/PaystackSDKTests/Common/PSTestCase.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import Paystack
+@testable import PaystackSDK
 
 class PSTestCase: XCTestCase {
     

--- a/Tests/PaystackSDKTests/Core/CryptographyTests.swift
+++ b/Tests/PaystackSDKTests/Core/CryptographyTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Paystack
+@testable import PaystackSDK
 
 final class CryptographyTests: XCTestCase {
     var serviceUnderTest: Cryptography!

--- a/Tests/PaystackSDKTests/Core/PaystackBuilderTests.swift
+++ b/Tests/PaystackSDKTests/Core/PaystackBuilderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import Paystack
+import PaystackSDK
 
 class PaystackBuilderTests: XCTestCase {
     

--- a/Tests/PaystackSDKTests/Core/ServiceTests.swift
+++ b/Tests/PaystackSDKTests/Core/ServiceTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import Paystack
+import PaystackSDK
 
 class ServiceTests: PSTestCase {
     

--- a/Tests/PaystackSDKTests/Core/URLRequestBuilderTests.swift
+++ b/Tests/PaystackSDKTests/Core/URLRequestBuilderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import Paystack
+import PaystackSDK
 
 class URLRequestBuilderTests: XCTestCase {
     


### PR DESCRIPTION
This is a prerequisite PR for further changes where we will be generating binary frameworks for cocoapods.

I have found an issue though, when generating our binary, if we have a class with the same name as the module itself, the binary fails to compile. Both our module and our main class that is created by the builder are called `Paystack`.

I've opted to rename the module itself as the library for it declared in the Package file is already called PaystackSDK and so it makes sense to call the target the same name. I also feel like having the name of our main class remain `Paystack` is ideal.

Curious to hear thoughts if anyone things we should preserve the module name instead of the class name