### PR TITLE
MOB-305 Added service calls for endpoints for charge authentication

### DIFF
--- a/Sources/PaystackSDK/API/Charge/ChargeService.swift
+++ b/Sources/PaystackSDK/API/Charge/ChargeService.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+protocol ChargeService: PaystackService {
+    func postSubmitPin(_ request: SubmitPinRequest) -> Service<ChargeAuthenticationResponse>
+    func postSubmitOtp(_ request: SubmitOtpRequest) -> Service<ChargeAuthenticationResponse>
+    func postSubmitPhone(_ request: SubmitPhoneRequest) -> Service<ChargeAuthenticationResponse>
+    func postSubmitBirthday(_ request: SubmitBirthdayRequest) -> Service<ChargeAuthenticationResponse>
+    func postSubmitAddress(_ request: SubmitAddressRequest) -> Service<ChargeAuthenticationResponse>
+}
+
+struct ChargeServiceImplementation: ChargeService {
+    var config: PaystackConfig
+
+    var parentPath: String {
+        return "charge"
+    }
+
+    func postSubmitPin(_ request: SubmitPinRequest) -> Service<ChargeAuthenticationResponse> {
+        return post("/submit_pin", request)
+            .asService()
+    }
+
+    func postSubmitOtp(_ request: SubmitOtpRequest) -> Service<ChargeAuthenticationResponse> {
+        return post("/submit_otp", request)
+            .asService()
+    }
+
+    func postSubmitPhone(_ request: SubmitPhoneRequest) -> Service<ChargeAuthenticationResponse> {
+        return post("/submit_phone", request)
+            .asService()
+    }
+
+    func postSubmitBirthday(_ request: SubmitBirthdayRequest) -> Service<ChargeAuthenticationResponse> {
+        return post("/submit_birthday", request)
+            .asService()
+    }
+
+    func postSubmitAddress(_ request: SubmitAddressRequest) -> Service<ChargeAuthenticationResponse> {
+        return post("/submit_address", request)
+            .asService()
+    }
+
+}

--- a/Sources/PaystackSDK/Core/Models/Models/Authorization.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Authorization.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct Authorization: Codable {
+    var authorizationCode, bin, last4, expMonth: String?
+    var expYear, channel, cardType, bank: String?
+    var countryCode, brand: String?
+    var reusable: Bool?
+    var signature, accountName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case authorizationCode = "authorization_code"
+        case bin, last4
+        case expMonth = "exp_month"
+        case expYear = "exp_year"
+        case channel
+        case cardType = "card_type"
+        case bank
+        case countryCode = "country_code"
+        case brand, reusable, signature
+        case accountName = "account_name"
+    }
+}

--- a/Sources/PaystackSDK/Core/Models/Models/ChargeAuthentication.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/ChargeAuthentication.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public struct ChargeAuthentication: Codable {
+    var id: Int?
+    var domain, status, reference: String?
+    var amount: Int?
+    var message, gatewayResponse, dataPaidAt, dataCreatedAt: String?
+    var channel, currency, ipAddress, metadata: String?
+    var log: String?
+    var fees: Int?
+    var feesSplit: String?
+    var authorization: Authorization?
+    var customer: Customer?
+    var plan, split, orderID, paidAt: String?
+    var createdAt: String?
+    var requestedAmount: Int?
+    var posTransactionData, source, feesBreakdown, transactionDate: String?
+    var planObject, subaccount: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, domain, status, reference, amount, message
+        case gatewayResponse = "gateway_response"
+        case dataPaidAt = "paid_at"
+        case dataCreatedAt = "created_at"
+        case channel, currency
+        case ipAddress = "ip_address"
+        case metadata, log, fees
+        case feesSplit = "fees_split"
+        case authorization, customer, plan, split
+        case orderID = "order_id"
+        case paidAt, createdAt
+        case requestedAmount = "requested_amount"
+        case posTransactionData = "pos_transaction_data"
+        case source
+        case feesBreakdown = "fees_breakdown"
+        case transactionDate = "transaction_date"
+        case planObject = "plan_object"
+        case subaccount
+    }
+}

--- a/Sources/PaystackSDK/Core/Models/Models/ChargeAuthenticationResponse.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/ChargeAuthenticationResponse.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct ChargeAuthenticationResponse: Codable {
+    var status: Bool
+    var message: String
+    var data: ChargeAuthentication
+}

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitAddressRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitAddressRequest.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public struct SubmitAddressRequest: Codable {
+    public var address: String
+    public var city: String
+    public var state: String
+    public var zipCode: String
+    public var reference: String
+
+    enum CodingKeys: String, CodingKey {
+        case address, city, state, reference
+        case zipCode = "zip_code"
+    }
+}

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitBirthdayRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitBirthdayRequest.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct SubmitBirthdayRequest: Codable {
+    public var birthday: String
+    public var reference: String
+}

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitOtpRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitOtpRequest.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct SubmitOtpRequest: Codable {
+    public var otp: String
+    public var reference: String
+}

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitPhoneRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitPhoneRequest.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct SubmitPhoneRequest: Codable {
+    public var phone: String
+    public var reference: String
+}

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitPinRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitPinRequest.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct SubmitPinRequest: Codable {
+    public var pin: String
+    public var reference: String
+}


### PR DESCRIPTION
# Context:
We're creating the basic service calls for the different types of auth after charging a card. Note, this is the internal calls and there will be a wrapper created around this to be used publically. Unit tests will be added once I add the public wrapper.

# Changes:
- Added models for the different auth payload requests
- Added models for the response we receive
- Created `ChargeServiceImplementation` which is responsible for the different auth endpoints