### PR TITLE
MOB-364 Added logging to SDK

### DIFF
--- a/Sources/PaystackSDK/Core/Service/Subscription/PusherSubscriptionListener.swift
+++ b/Sources/PaystackSDK/Core/Service/Subscription/PusherSubscriptionListener.swift
@@ -29,13 +29,12 @@ struct PusherSubscriptionListener: SubscriptionListener {
     }
 
     private func bindConnectionEvents(to channel: PusherChannel) {
-        channel.bind(eventName: "pusher:subscription_succeeded", eventCallback: { event in
-            // TODO: Add proper logging
-            print(event.eventName)
+        Log.info("Pusher subscription initiated to %@", arguments: channel.name)
+        channel.bind(eventName: "pusher:subscription_succeeded", eventCallback: { _ in
+            Log.info("Pusher subscription succeeded to %@", arguments: channel.name)
         })
-        channel.bind(eventName: "pusher:subscription_error", eventCallback: { event in
-            // TODO: Add proper logging
-            print(event.eventName)
+        channel.bind(eventName: "pusher:subscription_error", eventCallback: { _ in
+            Log.error("Pusher subscription failed to %@", arguments: channel.name)
         })
     }
 

--- a/Sources/PaystackSDK/Core/Utils/Log.swift
+++ b/Sources/PaystackSDK/Core/Utils/Log.swift
@@ -1,0 +1,54 @@
+import Foundation
+import os
+
+// Note: We are currently forced to use os_log since we are supporting iOS 13. When we eventually drop support, we should change this to use the new iOS 14 Logger API.
+public final class Log {
+
+    private static var logger = OSLog(subsystem: "com.paystack.ios_sdk", category: "main")
+
+    /// Logs a message with the `default` type
+    /// - Parameters:
+    ///   - message: A constant string or format string that produces a human-readable log message
+    ///   - arguments: If message is a constant string, do not specify arguments.
+    ///     If message is a format string, pass the expected number of arguments in the order that they appear in the string.
+    public class func `default`(_ message: StaticString, arguments: CVarArg...) {
+        os_log(message, log: logger, type: .default, arguments)
+    }
+
+    /// Logs a message with the `info` type
+    /// - Parameters:
+    ///   - message: A constant string or format string that produces a human-readable log message
+    ///   - arguments: If message is a constant string, do not specify arguments.
+    ///     If message is a format string, pass the expected number of arguments in the order that they appear in the string.
+    public class func info(_ message: StaticString, arguments: CVarArg...) {
+        os_log(message, log: logger, type: .info, arguments)
+    }
+
+    /// Logs a message with the `debug` type
+    /// - Parameters:
+    ///   - message: A constant string or format string that produces a human-readable log message
+    ///   - arguments: If message is a constant string, do not specify arguments.
+    ///     If message is a format string, pass the expected number of arguments in the order that they appear in the string.
+    public class func debug(_ message: StaticString, arguments: CVarArg...) {
+        os_log(message, log: logger, type: .debug, arguments)
+    }
+
+    /// Logs a message with the `error` type
+    /// - Parameters:
+    ///   - message: A constant string or format string that produces a human-readable log message
+    ///   - arguments: If message is a constant string, do not specify arguments.
+    ///     If message is a format string, pass the expected number of arguments in the order that they appear in the string.
+    public class func error(_ message: StaticString, arguments: CVarArg...) {
+        os_log(message, log: logger, type: .error, arguments)
+    }
+
+    /// Logs a message with the `fault` type
+    /// - Parameters:
+    ///   - message: A constant string or format string that produces a human-readable log message
+    ///   - arguments: If message is a constant string, do not specify arguments.
+    ///     If message is a format string, pass the expected number of arguments in the order that they appear in the string.
+    public class func fault(_ message: StaticString, arguments: CVarArg...) {
+        os_log(message, log: logger, type: .fault, arguments)
+    }
+
+}


### PR DESCRIPTION
# Changes:
- Created `Log` which is responsible for using the Swift `OSLog` under the hood to enable creating logs from the SDK
Note: Ideally we would want to use the newer `Logger` here but can't due to our minimum iOS version. Once we do change this, this should be changed as well
-  Made use of `Log` inside the `PusherSubscriptionListener` to create useful logs to debug potential issues that would come from Pusher subscriptions
