### PR TITLE
Modified exposed endpoints to align with discussed approach

### DIFF
--- a/Sources/PaystackSDK/API/Charge/Charge.swift
+++ b/Sources/PaystackSDK/API/Charge/Charge.swift
@@ -5,22 +5,57 @@ public extension Paystack {
         return ChargeServiceImplementation(config: config)
     }
 
-    /// Continues the Charge flow by authenticating a user
-    /// - Parameter authenticationType: The type of authentication with the associated payload with reference provided.
+    /// Continues the Charge flow by authenticating a user with an OTP
+    /// - Parameters:
+    ///   - otp: The OTP sent to the user's device
+    ///   - reference: The reference of the current transaction
     /// - Returns: A ``Service`` with the results of the authentication
-    func authenticateCharge(_ authenticationType: AuthenticationType) -> Service<ChargeAuthenticationResponse> {
-        switch authenticationType {
-        case .otp(let otpPayload):
-            return service.postSubmitOtp(otpPayload)
-        case .pin(let pinPayload):
-            return service.postSubmitPin(pinPayload)
-        case .phone(let phonePayload):
-            return service.postSubmitPhone(phonePayload)
-        case .birthday(let birthdayPayload):
-            return service.postSubmitBirthday(birthdayPayload)
-        case .address(let addressPayload):
-            return service.postSubmitAddress(addressPayload)
-        }
+    func authenticateCharge(withOtp otp: String, reference: String) -> Service<ChargeAuthenticationResponse> {
+        let request = SubmitOtpRequest(otp: otp, reference: reference)
+        return service.postSubmitOtp(request)
+    }
+
+    /// Continues the Charge flow by authenticating a user with a Pin
+    /// - Parameters:
+    ///   - pin: The user's card pin
+    ///   - reference: The reference of the current transaction
+    /// - Returns: A ``Service`` with the results of the authentication
+    func authenticateCharge(withPin pin: String, reference: String) -> Service<ChargeAuthenticationResponse> {
+        let request = SubmitPinRequest(pin: pin, reference: reference)
+        return service.postSubmitPin(request)
+    }
+
+    /// Continues the Charge flow by authenticating a user with a phone number
+    /// - Parameters:
+    ///   - phone: The user's phone number associated with the card
+    ///   - reference: The reference of the current transaction
+    /// - Returns: A ``Service`` with the results of the authentication
+    func authenticateCharge(withPhone phone: String,
+                            reference: String) -> Service<ChargeAuthenticationResponse> {
+        let request = SubmitPhoneRequest(phone: phone, reference: reference)
+        return service.postSubmitPhone(request)
+    }
+
+    /// Continues the Charge flow by authenticating a user with their birthday
+    /// - Parameters:
+    ///   - birthday: The user's birthday in ISO 8601 format
+    ///   - reference: The reference of the current transaction
+    /// - Returns: A ``Service`` with the results of the authentication
+    func authenticateCharge(withBirthday birthday: String,
+                            reference: String) -> Service<ChargeAuthenticationResponse> {
+        let request = SubmitBirthdayRequest(birthday: birthday, reference: reference)
+        return service.postSubmitBirthday(request)
+    }
+
+    /// Continues the Charge flow by authenticating a user with their address
+    /// - Parameters:
+    ///   - address: An ``Address`` object describing the user's address
+    ///   - reference: The reference of the current transaction
+    /// - Returns: A ``Service`` with the results of the authentication
+    func authenticateCharge(withAddress address: Address,
+                            reference: String) -> Service<ChargeAuthenticationResponse> {
+        let request = SubmitAddressRequest(address: address, reference: reference)
+        return service.postSubmitAddress(request)
     }
 
     /// Listens for a response after presenting a 3DS URL in a webview for authentication

--- a/Sources/PaystackSDK/Core/Models/Address.swift
+++ b/Sources/PaystackSDK/Core/Models/Address.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct Address {
+    public var address: String
+    public var city: String
+    public var state: String
+    public var zipCode: String
+
+    public init(address: String, city: String, state: String, zipCode: String) {
+        self.address = address
+        self.city = city
+        self.state = state
+        self.zipCode = zipCode
+    }
+}

--- a/Sources/PaystackSDK/Core/Models/AuthenticationType.swift
+++ b/Sources/PaystackSDK/Core/Models/AuthenticationType.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-public enum AuthenticationType {
-    case otp(SubmitOtpRequest)
-    case pin(SubmitPinRequest)
-    case phone(SubmitPhoneRequest)
-    case birthday(SubmitBirthdayRequest)
-    case address(SubmitAddressRequest)
-}

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitAddressRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitAddressRequest.swift
@@ -1,11 +1,19 @@
 import Foundation
 
-public struct SubmitAddressRequest: Codable {
-    public var address: String
-    public var city: String
-    public var state: String
-    public var zipCode: String
-    public var reference: String
+struct SubmitAddressRequest: Codable {
+    var address: String
+    var city: String
+    var state: String
+    var zipCode: String
+    var reference: String
+
+    init(address: Address, reference: String) {
+        self.address = address.address
+        self.city = address.city
+        self.state = address.state
+        self.zipCode = address.zipCode
+        self.reference = reference
+    }
 
     enum CodingKeys: String, CodingKey {
         case address, city, state, reference

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitBirthdayRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitBirthdayRequest.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct SubmitBirthdayRequest: Codable {
-    public var birthday: String
-    public var reference: String
+struct SubmitBirthdayRequest: Codable {
+    var birthday: String
+    var reference: String
 }

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitOtpRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitOtpRequest.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct SubmitOtpRequest: Codable {
-    public var otp: String
-    public var reference: String
+struct SubmitOtpRequest: Codable {
+    var otp: String
+    var reference: String
 }

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitPhoneRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitPhoneRequest.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct SubmitPhoneRequest: Codable {
-    public var phone: String
-    public var reference: String
+struct SubmitPhoneRequest: Codable {
+    var phone: String
+    var reference: String
 }

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitPinRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitPinRequest.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct SubmitPinRequest: Codable {
-    public var pin: String
-    public var reference: String
+struct SubmitPinRequest: Codable {
+    var pin: String
+    var reference: String
 }

--- a/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
+++ b/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
@@ -24,7 +24,7 @@ final class ChargeTests: PSTestCase {
             .expectBody(otpRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(.otp(otpRequestBody)).sync()
+        _ = try serviceUnderTest.authenticateCharge(withOtp: "12345", reference: "abcde").sync()
     }
 
     func testAuthenticateChargeWithPinAuthentication() throws {
@@ -37,7 +37,7 @@ final class ChargeTests: PSTestCase {
             .expectBody(pinRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(.pin(pinRequestBody)).sync()
+        _ = try serviceUnderTest.authenticateCharge(withPin: "1234", reference: "abcde").sync()
     }
 
     func testAuthenticateChargeWithPhoneAuthentication() throws {
@@ -50,7 +50,7 @@ final class ChargeTests: PSTestCase {
             .expectBody(phoneRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(.phone(phoneRequestBody)).sync()
+        _ = try serviceUnderTest.authenticateCharge(withPhone: "0111234567", reference: "abcde").sync()
     }
 
     func testAuthenticateChargeWithBirthdayAuthentication() throws {
@@ -63,14 +63,13 @@ final class ChargeTests: PSTestCase {
             .expectBody(birthdayRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(.birthday(birthdayRequestBody)).sync()
+        _ = try serviceUnderTest.authenticateCharge(withBirthday: "1990-01-01", reference: "abcde").sync()
     }
 
     func testAuthenticateChargeWithAddressAuthentication() throws {
-        let addressRequestBody = SubmitAddressRequest(address: "123 Road",
-                                                      city: "Johannesburg",
-                                                      state: "Gauteng",
-                                                      zipCode: "1234",
+        let address = Address(address: "123 Road", city: "Johannesburg",
+                              state: "Gauteng", zipCode: "1234")
+        let addressRequestBody = SubmitAddressRequest(address: address,
                                                       reference: "abcde")
 
         mockServiceExecutor
@@ -80,7 +79,7 @@ final class ChargeTests: PSTestCase {
             .expectBody(addressRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(.address(addressRequestBody)).sync()
+        _ = try serviceUnderTest.authenticateCharge(withAddress: address, reference: "abcde").sync()
     }
 
     func testListenFor3DS() throws {


### PR DESCRIPTION
# Changes:
- Changed `authenticateCharge` from being a single call to having a separate call for each authentication type
- Cleaned up the method to no longer require a model to be provided for most cases, and rather take primitive parameter types
- Created an `Address` specifically for address as it's a bit longer than other types
- Made models non-public that no longer require it
- Updated unit tests for changes

# Reference: 
https://www.notion.so/paystack/Methods-to-be-Exposed-849324fde56642d38e56c9bd67f78fdc