### PR TITLE
Added functionality to enable button when form is valid

### DIFF
--- a/Sources/PaystackUI/Charge/CardDetails/CardDetailsViewModel.swift
+++ b/Sources/PaystackUI/Charge/CardDetails/CardDetailsViewModel.swift
@@ -26,7 +26,9 @@ class CardDetailsViewModel: ObservableObject {
     }
 
     var isValid: Bool {
-        false
+        cvv.count == maximumCvvDigits &&
+        cardExpiry.count == 7 &&
+        cardNumber.removingAllWhitespaces.count >= cardType.minimumDigits
     }
 
     var maximumCvvDigits: Int {

--- a/Sources/PaystackUI/Charge/CardDetails/Models/CardType.swift
+++ b/Sources/PaystackUI/Charge/CardDetails/Models/CardType.swift
@@ -30,6 +30,17 @@ extension CardType {
         }
     }
 
+    var minimumDigits: Int {
+        switch self {
+        case .amex:
+            return 15
+        case .diners:
+            return 14
+        default:
+            return 16
+        }
+    }
+
     var regularExpression: String {
         switch self {
         case .amex:

--- a/Tests/PaystackSDKTests/UI/Charge/CardDetails/CardDetailsViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardDetails/CardDetailsViewModelTests.swift
@@ -47,4 +47,29 @@ final class CardDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(serviceUnderTest.cardExpiry, "08 /")
     }
 
+    func testFormIsInvalidIfNoDataIsEntered() {
+        XCTAssertFalse(serviceUnderTest.isValid)
+    }
+
+    func testFormIsInvalidWhenFieldsHaveDataButDoNotMatchLength() {
+        serviceUnderTest.cardExpiry = "01 / "
+        serviceUnderTest.cardNumber = "1234 5678 9"
+        serviceUnderTest.cvv = "12"
+        XCTAssertFalse(serviceUnderTest.isValid)
+    }
+
+    func testFormIsInvalidWhenOnlySomeFieldsMeetRequirements() {
+        serviceUnderTest.cardExpiry = "01 / 23"
+        serviceUnderTest.cardNumber = "1234 5678 9012 1234"
+        serviceUnderTest.cvv = "1"
+        XCTAssertFalse(serviceUnderTest.isValid)
+    }
+
+    func testFormIsValidWhenAllFieldsMatchRequirements() {
+        serviceUnderTest.cardExpiry = "01 / 23"
+        serviceUnderTest.cardNumber = "1234 5678 9012 1234"
+        serviceUnderTest.cvv = "123"
+        XCTAssertTrue(serviceUnderTest.isValid)
+    }
+
 }


### PR DESCRIPTION
# Changes:
This one is pretty simple. Just added a check to the view model to see when all fields match minimum length requirements before enabling the form.

# Visual:
![Simulator Screen Recording - iPhone 14 Pro - 2023-07-07 at 11 21 27](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/eded4424-4597-44ae-9bbb-e88421dc4c62)