### PR TITLE
Refactored close button

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeView.swift
+++ b/Sources/PaystackUI/Charge/ChargeView.swift
@@ -7,6 +7,9 @@ struct ChargeView: View {
     @StateObject
     var viewModel: ChargeViewModel
 
+    @EnvironmentObject
+    var visibilityContainer: ViewVisibilityContainer
+
     init(accessCode: String, paystack: Paystack) {
         self._viewModel = StateObject(
             wrappedValue: ChargeViewModel(
@@ -26,5 +29,10 @@ struct ChargeView: View {
             }
         }
         .task(viewModel.verifyAccessCodeAndProceedWithCard)
+        .modalCancelButton(onCancelled: chargeCancelled)
+    }
+
+    func chargeCancelled() {
+        visibilityContainer.cancelAndDismiss()
     }
 }

--- a/Sources/PaystackUI/Components/ModalCancelButton.swift
+++ b/Sources/PaystackUI/Components/ModalCancelButton.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+// TODO: Replace constants from Design System
+@available(iOS 14.0, *)
+struct ModalCancelButton: ViewModifier {
+
+    @State
+    var confirmationDialogDisplayed = false
+
+    var displayConfirmationDialog: Bool
+    var onCancellation: () -> Void
+
+    init(displayConfirmationDialog: Bool,
+         onCancellation: @escaping () -> Void) {
+        self.displayConfirmationDialog = displayConfirmationDialog
+        self.onCancellation = onCancellation
+    }
+
+    func body(content: Content) -> some View {
+        NavigationView {
+            if displayConfirmationDialog {
+                content
+                    .confirmationDialog(title: "Do you want to abort this transaction?",
+                                        isPresented: $confirmationDialogDisplayed,
+                                        confirmationText: "Abort Transaction",
+                                        onConfirmation: onCancellation)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            closeButton
+                        }
+                    }
+            } else {
+                content
+            }
+        }
+
+    }
+
+    private var closeButton: some View {
+        Button(action: closeButtonTapped) {
+            Image(systemName: "xmark")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(.gray)
+        }
+    }
+
+    private func closeButtonTapped() {
+        if displayConfirmationDialog {
+            confirmationDialogDisplayed = true
+        } else {
+            onCancellation()
+        }
+    }
+}
+
+@available(iOS 14.0, *)
+extension View {
+
+    @ViewBuilder
+    func modalCancelButton(shouldDisplay: Bool = true,
+                           showConfirmation: Bool = true,
+                           onCancelled: @escaping () -> Void) -> some View {
+        if shouldDisplay {
+            self.modifier(ModalCancelButton(displayConfirmationDialog: showConfirmation,
+                                            onCancellation: onCancelled))
+        } else {
+            self
+        }
+    }
+
+}

--- a/Sources/PaystackUI/Components/NavigationalButton.swift
+++ b/Sources/PaystackUI/Components/NavigationalButton.swift
@@ -23,22 +23,13 @@ struct NavigationalButton<Content: View, Destination: View>: View {
         Button(action: startFlow) {
             content
         }
-        .paymentSheet(isPresented: $visibilityContainer.showModal,
-                      onCloseTapped: closeButtonTapped) {
+        .paymentSheet(isPresented: $visibilityContainer.showModal) {
             destination
-                .confirmationDialog(title: "Do you want to abort this transaction?",
-                                    isPresented: $visibilityContainer.showCancellationConfirmation,
-                                    confirmationText: "Abort Transaction",
-                                    onConfirmation: visibilityContainer.cancelAndDismiss)
         }
         .environmentObject(visibilityContainer)
     }
 
     func startFlow() {
         visibilityContainer.showModal = true
-    }
-
-    func closeButtonTapped() {
-        visibilityContainer.showCancellationConfirmation = true
     }
 }

--- a/Sources/PaystackUI/Components/PaymentSheet.swift
+++ b/Sources/PaystackUI/Components/PaymentSheet.swift
@@ -4,28 +4,11 @@ import SwiftUI
 extension View {
 
     func paymentSheet<Content: View>(isPresented: Binding<Bool>,
-                                     onCloseTapped: @escaping () -> Void,
                                      @ViewBuilder content: @escaping () -> Content) -> some View {
         sheet(isPresented: isPresented) {
-            NavigationView {
-                content()
-                    .toolbar {
-                        ToolbarItem(placement: .cancellationAction) {
-                            closeButton(with: onCloseTapped)
-                        }
-                    }
-            }
-            .preventSheetSwipeDismissal()
-            .setSheetHeight()
-        }
-    }
-
-    private func closeButton(with action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            // TODO: Use from Design System
-            Image(systemName: "xmark")
-                .font(.system(size: 18, weight: .bold))
-                .foregroundColor(.gray)
+            content()
+                .preventSheetSwipeDismissal()
+                .setSheetHeight()
         }
     }
 

--- a/Sources/PaystackUI/Components/ViewVisibilityContainer.swift
+++ b/Sources/PaystackUI/Components/ViewVisibilityContainer.swift
@@ -5,9 +5,6 @@ class ViewVisibilityContainer: ObservableObject {
     @Published
     var showModal: Bool
 
-    @Published
-    var showCancellationConfirmation: Bool = false
-
     var onComplete: (TransactionResult) -> Void
 
     #if os(iOS)


### PR DESCRIPTION
# Discussion:
Whilst looking at the design I've come to the conclusion that there may be screens where we want to override the close button functionality/potentially not show the close button at all.
Additionally and more importantly, the current approach would not have worked properly for those using UIKit as the functionality lived in the SwiftUI `NavigationButton` only.

This has been refactored to be more usable now.