### PR TITLE
Cancel payment and return to start of flow

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
@@ -18,10 +18,12 @@ struct CardDetailsView: View {
     @State
     private var showExpiryError = false
 
-    init(amountDetails: AmountCurrency) {
+    init(amountDetails: AmountCurrency,
+         chargeCardContainer: ChargeCardContainer) {
         self._viewModel = StateObject(
             wrappedValue: CardDetailsViewModel(
-                amountDetails: amountDetails))
+                amountDetails: amountDetails,
+                chargeCardContainer: chargeCardContainer))
     }
 
     var body: some View {
@@ -112,7 +114,10 @@ struct CardDetailsView: View {
 @available(iOS 14.0, *)
 struct CardDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        CardDetailsView(amountDetails: .init(amount: 100,
-                                             currency: "USD"))
+        CardDetailsView(
+            amountDetails: .init(amount: 10000,
+                                 currency: "USD"),
+            chargeCardContainer: ChargeCardViewModel(
+                amountDetails: .init(amount: 10000, currency: "USD")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsViewModel.swift
@@ -16,9 +16,12 @@ class CardDetailsViewModel: ObservableObject {
     var cardType: CardType = .unknown
 
     var amountDetails: AmountCurrency
+    var chargeCardContainer: ChargeCardContainer
 
-    init(amountDetails: AmountCurrency) {
+    init(amountDetails: AmountCurrency,
+         chargeCardContainer: ChargeCardContainer) {
         self.amountDetails = amountDetails
+        self.chargeCardContainer = chargeCardContainer
     }
 
     var buttonTitle: String {

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardContainer.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardContainer.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol ChargeCardContainer {
+    func restartCardPayment()
+}

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -13,9 +13,10 @@ struct ChargeCardView: View {
     var body: some View {
         switch viewModel.chargeCardState {
         case .cardDetails(let amount):
-            CardDetailsView(amountDetails: amount)
+            CardDetailsView(amountDetails: amount,
+                            chargeCardContainer: viewModel)
         case .pin:
-            CardPinView()
+            CardPinView(chargeCardContainer: viewModel)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -1,11 +1,18 @@
 import Foundation
 
-class ChargeCardViewModel: ObservableObject {
+class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
 
     @Published
     var chargeCardState: ChargeCardState
 
+    var amountDetails: AmountCurrency
+
     init(amountDetails: AmountCurrency) {
+        self.amountDetails = amountDetails
         self.chargeCardState = .cardDetails(amount: amountDetails)
+    }
+
+    func restartCardPayment() {
+        chargeCardState = .cardDetails(amount: amountDetails)
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinView.swift
@@ -5,7 +5,12 @@ import SwiftUI
 struct CardPinView: View {
 
     @StateObject
-    var viewModel = CardPinViewModel()
+    var viewModel: CardPinViewModel
+
+    init(chargeCardContainer: ChargeCardContainer) {
+        self._viewModel = StateObject(wrappedValue: CardPinViewModel(
+            chargeCardContainer: chargeCardContainer))
+    }
 
     var body: some View {
         VStack(spacing: 24) {
@@ -45,6 +50,7 @@ struct CardPinView: View {
 @available(iOS 14.0, *)
 struct CardPinView_Previews: PreviewProvider {
     static var previews: some View {
-        CardPinView()
+        CardPinView(chargeCardContainer: ChargeCardViewModel(
+            amountDetails: .init(amount: 100000, currency: "USD")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinViewModel.swift
@@ -8,12 +8,18 @@ class CardPinViewModel: ObservableObject {
     @Published
     var showLoading = false
 
+    var chargeCardContainer: ChargeCardContainer
+
+    init(chargeCardContainer: ChargeCardContainer) {
+        self.chargeCardContainer = chargeCardContainer
+    }
+
     func submitPin() {
         showLoading = true
         // TODO: Perform API call
     }
 
     func cancelTransaction() {
-        // TODO: Add cancel transaction functionality in the next PR
+        chargeCardContainer.restartCardPayment()
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardDetails/CardDetailsViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardDetails/CardDetailsViewModelTests.swift
@@ -5,10 +5,13 @@ final class CardDetailsViewModelTests: XCTestCase {
 
     var serviceUnderTest: CardDetailsViewModel!
     var mockAmountCurrency = AmountCurrency(amount: 100, currency: "USD")
+    var mockChargeCardContainer: MockChargeCardContainer!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        serviceUnderTest = CardDetailsViewModel(amountDetails: mockAmountCurrency)
+        mockChargeCardContainer = MockChargeCardContainer()
+        serviceUnderTest = CardDetailsViewModel(amountDetails: mockAmountCurrency,
+                                                chargeCardContainer: mockChargeCardContainer)
     }
 
     func testWhenCardNumberChangesThatCardTypeUpdatesToReflectCorrectTypeAndFormatsCorrectly() {

--- a/Tests/PaystackSDKTests/UI/Charge/CardPin/CardPinViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardPin/CardPinViewModelTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import PaystackUI
+
+final class CardPinViewModelTests: XCTestCase {
+
+    var serviceUnderTest: CardPinViewModel!
+    var mockChargeCardContainer: MockChargeCardContainer!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mockChargeCardContainer = MockChargeCardContainer()
+        serviceUnderTest = CardPinViewModel(chargeCardContainer: mockChargeCardContainer)
+    }
+
+    func testCancelTransactionCallsContainerToRestartCardFlow() {
+        serviceUnderTest.cancelTransaction()
+        XCTAssertTrue(mockChargeCardContainer.cardPaymentRestarted)
+    }
+
+}

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import PaystackUI
+
+final class ChargeCardViewModelTests: PSTestCase {
+
+    var serviceUnderTest: ChargeCardViewModel!
+    var mockAmountCurrency = AmountCurrency(amount: 10000, currency: "USD")
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        serviceUnderTest = ChargeCardViewModel(amountDetails: mockAmountCurrency)
+    }
+
+    func testRestartCardPaymentResetsStateToCardDetailsWithAmount() {
+        serviceUnderTest.chargeCardState = .pin
+        serviceUnderTest.restartCardPayment()
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+            .cardDetails(amount: mockAmountCurrency))
+    }
+
+}
+
+extension ChargeCardState: Equatable {
+    public static func == (lhs: ChargeCardState, rhs: ChargeCardState) -> Bool {
+        switch (lhs, rhs) {
+        case (.cardDetails(let first), .cardDetails(let second)):
+            return first == second
+        case (.pin, .pin):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardContainer.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardContainer.swift
@@ -1,0 +1,12 @@
+import Foundation
+@testable import PaystackUI
+
+class MockChargeCardContainer: ChargeCardContainer {
+
+    var cardPaymentRestarted = false
+
+    func restartCardPayment() {
+        cardPaymentRestarted = true
+    }
+
+}


### PR DESCRIPTION
# Changes:
- Introduced a `ChargeCardContainer` protocol that is conformed to by the `ChargeCardViewModel`
- The above protocol is now passed into the card children views as a way of communicating with the parent for state changes
- Added a `restartCardPayment` function to the protocol which resets the flow to the beginning
- Added unit tests and mocks

# Visuals:
![Simulator Screen Recording - iPhone 14 Pro - 2023-07-19 at 16 18 43](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/d777a904-2bd7-4d05-828c-a1072ad33c2d)