### PR TITLE
Built Error View and related components

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -31,6 +31,11 @@ struct ChargeCardView: View {
 
         case .birthday:
             CardBirthdayView(chargeCardContainer: viewModel)
+
+        case .error(let error):
+            ErrorView(message: error.message,
+                      buttonText: "Try another card",
+                      buttonAction: viewModel.restartCardPayment)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardError.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// TODO: Add error states here once we identify further examples
+enum ChargeCardError: Error {
+    case incorrectStreetAddress
+}
+
+extension ChargeCardError {
+    var message: String {
+        switch self {
+        case .incorrectStreetAddress:
+            return "Street address does not match"
+        }
+    }
+}

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
@@ -7,4 +7,5 @@ enum ChargeCardState {
     case otp(phoneNumber: String)
     case address(states: [String])
     case birthday
+    case error(ChargeCardError)
 }

--- a/Sources/PaystackUI/Components/ErrorView.swift
+++ b/Sources/PaystackUI/Components/ErrorView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+// TODO: Move this to the design system and replace colors/fonts
+@available(iOS 14.0, *)
+struct ErrorView: View {
+
+    var message: String
+    var buttonText: String
+    var buttonAction: () -> Void
+
+    init(message: String, buttonText: String, buttonAction: @escaping () -> Void) {
+        self.message = message
+        self.buttonText = buttonText
+        self.buttonAction = buttonAction
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image.errorIcon
+
+            Text(message)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 8)
+
+            Button(buttonText, action: buttonAction)
+                .buttonStyle(SecondaryButtonStyle())
+        }
+        .padding(16)
+    }
+}
+
+@available(iOS 14.0, *)
+struct ErrorView_Previews: PreviewProvider {
+    static var previews: some View {
+        ErrorView(message: "Street address does not match",
+                  buttonText: "Try another card",
+                  buttonAction: {})
+    }
+}

--- a/Sources/PaystackUI/Components/Styles/SecondaryButtonStyle.swift
+++ b/Sources/PaystackUI/Components/Styles/SecondaryButtonStyle.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+// TODO: Move this to the design system and replace colors/fonts
+@available(iOS 14.0, *)
+struct SecondaryButtonStyle: ButtonStyle {
+
+    var showLoading: Bool
+
+    init(showLoading: Bool = false) {
+        self.showLoading = showLoading
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        VStack {
+            if showLoading {
+                LoadingIndicator(tintColor: foreground)
+            } else {
+                configuration.label
+            }
+        }
+        .padding()
+        .frame(height: 56)
+        .frame(maxWidth: .infinity)
+        .font(.body)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(configuration.isPressed ?
+                        border : pressedBorder, lineWidth: 1)
+        )
+        .foregroundColor(configuration.isPressed ? pressedForeground : foreground)
+        .cornerRadius(8)
+        .disabled(showLoading)
+    }
+
+}
+
+// TODO: These values are all incorrect and will be pulled from Design when available
+// TODO: Remove pressed states if we later decided that they will be
+@available(iOS 14.0, *)
+extension SecondaryButtonStyle {
+
+    var border: Color {
+        .green
+    }
+
+    var pressedBorder: Color {
+        .green
+    }
+
+    var foreground: Color {
+        .green
+    }
+
+    var pressedForeground: Color {
+        .green
+    }
+
+}
+
+@available(iOS 14.0, *)
+struct SecondaryButtonStyle_Previews: PreviewProvider {
+    static var previews: some View {
+        Button("Example", action: {})
+            .buttonStyle(SecondaryButtonStyle(showLoading: false))
+            .padding()
+    }
+}

--- a/Sources/PaystackUI/Images/Images.swift
+++ b/Sources/PaystackUI/Images/Images.swift
@@ -64,4 +64,12 @@ extension Image {
         Image(systemName: "arrowtriangle.down.circle.fill")
             .foregroundColor(.gray)
     }
+
+    static var errorIcon: some View {
+        Image(systemName: "exclamationmark.triangle.fill")
+            .resizable()
+            .foregroundColor(.orange)
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 32)
+    }
 }


### PR DESCRIPTION
# Changes:
- Created `ErrorView` which displays the error screen
- Created an enum `ChargeCardError` which will be used to represent all errors throughout the charge card flow
- Added an `error` case to `ChargeCardState` which takes in the enum from above
- Created a `SecondaryButtonStyle` for the new button style

# Visuals:
![Screenshot 2023-08-03 at 12 18 50](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/ebcaceae-6a59-4a91-8be8-8e8f66442065)
