### PR TITLE
Display tag when in test mode

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeView.swift
+++ b/Sources/PaystackUI/Charge/ChargeView.swift
@@ -23,6 +23,10 @@ struct ChargeView: View {
                 Spacer()
             }
 
+            if viewModel.inTestMode {
+                TestModeInidcator()
+            }
+
             switch viewModel.transactionState {
             case .loading(let message):
                 LoadingView(message: message)

--- a/Sources/PaystackUI/Charge/ChargeViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeViewModel.swift
@@ -51,4 +51,8 @@ extension ChargeViewModel {
             return true
         }
     }
+
+    var inTestMode: Bool {
+        transactionDetails?.domain == .test
+    }
 }

--- a/Sources/PaystackUI/Components/TestModeInidcator.swift
+++ b/Sources/PaystackUI/Components/TestModeInidcator.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+// TODO: Replace constants and colors from design system
+struct TestModeInidcator: View {
+
+    var body: some View {
+        Text("TEST")
+            .foregroundColor(Color(red: 0.4, green: 0.22, blue: 0))
+            .font(.caption)
+            .bold()
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .background(Color(red: 1, green: 0.96, blue: 0.87))
+            .overlay(
+                RoundedRectangle(cornerRadius: 3)
+                    .stroke(Color(red: 1, green: 0.89, blue: 0.72), lineWidth: 1)
+            )
+    }
+
+}
+
+struct TestModeInidcator_Previews: PreviewProvider {
+    static var previews: some View {
+        TestModeInidcator()
+    }
+}

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
@@ -45,6 +45,23 @@ final class ChargeViewModelTests: PSTestCase {
             amount: 100, currency: "USD"), merchant: "Test")
         XCTAssertFalse(serviceUnderTest.displayCloseButtonConfirmation)
     }
+
+    func testPaymentIsInTestModeWhenDomainIsSetToTest() {
+        serviceUnderTest.transactionDetails = .init(amount: 10000, currency: "USD",
+                                                    paymentChannels: [], domain: .test)
+        XCTAssertTrue(serviceUnderTest.inTestMode)
+    }
+
+    func testPaymentIsNotInTestModeWhenDomainIsSetToLive() {
+        serviceUnderTest.transactionDetails = .init(amount: 10000, currency: "USD",
+                                                    paymentChannels: [], domain: .live)
+        XCTAssertFalse(serviceUnderTest.inTestMode)
+    }
+
+    func testPaymentIsNotInTestModeWhenDomainIsNotSet() {
+        serviceUnderTest.transactionDetails = nil
+        XCTAssertFalse(serviceUnderTest.inTestMode)
+    }
 }
 
 extension ChargeState: Equatable {


### PR DESCRIPTION
# Changes:
- Created `TestModeInidcator` which is a the "tag view" displayed
- Added logic to `ChargeViewModel` to determine if the payment is in test mode
- Added code to `ChargeView` to display the tag when in test mode
- Added unit tests to `ChargeViewModelTests`

# Visuals:
![Screenshot 2023-08-04 at 11 16 40](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/c3c833b1-f35c-4dca-85b2-08b3bf9047c8)
