### PR TITLE
MOB-656 Display Card selection view

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressView.swift
@@ -25,7 +25,7 @@ struct CardAddressView: View {
                 FormInput(title: "Complete Payment",
                           enabled: viewModel.isValid,
                           action: viewModel.submitAddress,
-                          cancelAction: viewModel.cancelTransaction) {
+                          secondaryAction: viewModel.cancelTransaction) {
                     streetField
                     zipCodeField
 
@@ -74,6 +74,6 @@ struct CardAddressView_Previews: PreviewProvider {
     static var previews: some View {
         CardAddressView(states: [],
                         chargeCardContainer: ChargeCardViewModel(
-            amountDetails: .init(amount: 100000, currency: "USD")))
+                            transactionDetails: .example))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayView.swift
@@ -31,7 +31,8 @@ struct CardBirthdayView: View {
 
             FormInput(title: "Authorize",
                       enabled: viewModel.isValid,
-                      action: viewModel.submitPhoneNumber, cancelAction: viewModel.cancelTransaction) {
+                      action: viewModel.submitPhoneNumber,
+                      secondaryAction: viewModel.cancelTransaction) {
 
                 monthField
 
@@ -76,6 +77,6 @@ struct CardBirthdayView: View {
 struct CardBirthdayView_Previews: PreviewProvider {
     static var previews: some View {
         CardBirthdayView(chargeCardContainer: ChargeCardViewModel(
-            amountDetails: .init(amount: 100000, currency: "USD")))
+            transactionDetails: .example))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
@@ -97,6 +97,6 @@ struct CardDetailsView_Previews: PreviewProvider {
             amountDetails: .init(amount: 10000,
                                  currency: "USD"),
             chargeCardContainer: ChargeCardViewModel(
-                amountDetails: .init(amount: 10000, currency: "USD")))
+                transactionDetails: .example))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -6,8 +6,9 @@ struct ChargeCardView: View {
     @StateObject
     var viewModel: ChargeCardViewModel
 
-    init(amountDetails: AmountCurrency) {
-        self._viewModel = StateObject(wrappedValue: ChargeCardViewModel(amountDetails: amountDetails))
+    init(transactionDetails: VerifyAccessCode) {
+        self._viewModel = StateObject(
+            wrappedValue: ChargeCardViewModel(transactionDetails: transactionDetails))
     }
 
     var body: some View {

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -5,14 +5,17 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
     @Published
     var chargeCardState: ChargeCardState
 
-    var amountDetails: AmountCurrency
+    var transactionDetails: VerifyAccessCode
 
-    init(amountDetails: AmountCurrency) {
-        self.amountDetails = amountDetails
-        self.chargeCardState = .cardDetails(amount: amountDetails)
+    init(transactionDetails: VerifyAccessCode) {
+        self.transactionDetails = transactionDetails
+        let amountDetails = transactionDetails.amountCurrency
+        self.chargeCardState = transactionDetails.domain == .live ?
+            .cardDetails(amount: amountDetails) :
+            .testModeCardSelection(amount: amountDetails)
     }
 
     func restartCardPayment() {
-        chargeCardState = .cardDetails(amount: amountDetails)
+        chargeCardState = .cardDetails(amount: transactionDetails.amountCurrency)
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPVIew.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPVIew.swift
@@ -29,7 +29,7 @@ struct CardOTPVIew: View {
                 FormInput(title: "Authorize",
                           enabled: viewModel.isValid,
                           action: viewModel.submitOTP,
-                          cancelAction: viewModel.cancelTransaction,
+                          secondaryAction: viewModel.cancelTransaction,
                           supplementaryContent: resendOTPSection) {
                     otpField
                 }
@@ -86,6 +86,6 @@ struct CardOTPVIew_Previews: PreviewProvider {
     static var previews: some View {
         CardOTPVIew(phoneNumber: "+234801****5678",
                     chargeCardContainer: ChargeCardViewModel(
-            amountDetails: .init(amount: 100000, currency: "USD")))
+                        transactionDetails: .example))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneView.swift
@@ -27,7 +27,8 @@ struct CardPhoneView: View {
 
             FormInput(title: "Send OTP",
                       enabled: viewModel.isValid,
-                      action: viewModel.submitPhoneNumber, cancelAction: viewModel.cancelTransaction) {
+                      action: viewModel.submitPhoneNumber,
+                      secondaryAction: viewModel.cancelTransaction) {
                 phoneNumber
             }
         }
@@ -51,6 +52,6 @@ struct CardPhoneView: View {
 struct CardPhoneView_Previews: PreviewProvider {
     static var previews: some View {
         CardPhoneView(chargeCardContainer: ChargeCardViewModel(
-            amountDetails: .init(amount: 100000, currency: "USD")))
+            transactionDetails: .example))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinView.swift
@@ -51,6 +51,6 @@ struct CardPinView: View {
 struct CardPinView_Previews: PreviewProvider {
     static var previews: some View {
         CardPinView(chargeCardContainer: ChargeCardViewModel(
-            amountDetails: .init(amount: 100000, currency: "USD")))
+            transactionDetails: .example))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionView.swift
@@ -24,7 +24,9 @@ struct TestModeCardSelectionView: View {
 
                 FormInput(title: viewModel.buttonTitle,
                           enabled: viewModel.isValid,
-                          action: viewModel.proceedWithTestCard) {
+                          action: viewModel.proceedWithTestCard,
+                          secondaryButtonText: "Use another card",
+                          secondaryAction: viewModel.displayManualCardDetailsEntry) {
                     testCardOptions
                 }
             }
@@ -58,6 +60,6 @@ struct TestModeCardSelectionView_Previews: PreviewProvider {
             amountDetails: .init(amount: 10000,
                                  currency: "USD"),
             chargeCardContainer: ChargeCardViewModel(
-                amountDetails: .init(amount: 10000, currency: "USD")))
+                transactionDetails: .example))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionViewModel.swift
@@ -25,4 +25,8 @@ class TestModeCardSelectionViewModel: ObservableObject {
     func proceedWithTestCard(onComplete: @escaping () -> Void) {
         // TODO: Perform API call with card details
     }
+
+    func displayManualCardDetailsEntry() {
+        chargeCardContainer.restartCardPayment()
+    }
 }

--- a/Sources/PaystackUI/Charge/ChargeView.swift
+++ b/Sources/PaystackUI/Charge/ChargeView.swift
@@ -52,8 +52,8 @@ struct ChargeView: View {
     @ViewBuilder
     func paymentFlowView(for type: ChargePaymentType) -> some View {
         switch type {
-        case .card(let amountInformation):
-            ChargeCardView(amountDetails: amountInformation)
+        case .card(let transactionInformation):
+            ChargeCardView(transactionDetails: transactionInformation)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeViewModel.swift
@@ -23,7 +23,7 @@ class ChargeViewModel: ObservableObject {
             transactionState = .loading()
             let accessCodeResponse = try await repository.verifyAccessCode(accessCode)
             self.transactionDetails = accessCodeResponse
-            transactionState = .payment(type: .card(amountInformation: accessCodeResponse.amountCurrency))
+            transactionState = .payment(type: .card(transactionInformation: accessCodeResponse))
         } catch {
             transactionState = .error(error)
         }

--- a/Sources/PaystackUI/Charge/Models/ChargePaymentType.swift
+++ b/Sources/PaystackUI/Charge/Models/ChargePaymentType.swift
@@ -2,5 +2,5 @@ import Foundation
 
 // TODO: Add an extension to map from payment channels once those are defined
 enum ChargePaymentType: Equatable {
-    case card(amountInformation: AmountCurrency)
+    case card(transactionInformation: VerifyAccessCode)
 }

--- a/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
+++ b/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
@@ -23,3 +23,13 @@ extension VerifyAccessCode {
     }
 
 }
+
+// MARK: - Previews
+extension VerifyAccessCode {
+    static var example: Self {
+        .init(amount: 10000,
+              currency: "USD",
+              paymentChannels: [],
+              domain: .test)
+    }
+}

--- a/Sources/PaystackUI/Components/Form/FormInput.swift
+++ b/Sources/PaystackUI/Components/Form/FormInput.swift
@@ -12,19 +12,22 @@ struct FormInput<Content: View,
     var supplementaryContent: SupplementaryContent?
     var buttonTitle: String
     var buttonEnabled: Bool
-    var cancelAction: (() -> Void)?
+    var secondaryButtonText: String
+    var secondaryAction: (() -> Void)?
 
     init(title: String = "Submit",
          enabled: Bool = true,
          action: @escaping (@escaping () -> Void) -> Void,
-         cancelAction: (() -> Void)? = nil,
+         secondaryButtonText: String = "Cancel",
+         secondaryAction: (() -> Void)? = nil,
          supplementaryContent: SupplementaryContent,
          @FormInputDataBuilder content: () -> FormInputData<Content>) {
         let content = content()
         self.formData = content
         self.buttonTitle = title
         self.buttonEnabled = enabled
-        self.cancelAction = cancelAction
+        self.secondaryButtonText = secondaryButtonText
+        self.secondaryAction = secondaryAction
         self.supplementaryContent = supplementaryContent
         self._viewModel = StateObject(wrappedValue: FormInputViewModel(action: action))
     }
@@ -32,14 +35,16 @@ struct FormInput<Content: View,
     init(title: String = "Submit",
          enabled: Bool = true,
          action: @escaping (@escaping () -> Void) -> Void,
-         cancelAction: (() -> Void)? = nil,
+         secondaryButtonText: String = "Cancel",
+         secondaryAction: (() -> Void)? = nil,
          @FormInputDataBuilder content: () -> FormInputData<Content>)
     where SupplementaryContent == EmptyView {
         let content = content()
         self.formData = content
         self.buttonTitle = title
         self.buttonEnabled = enabled
-        self.cancelAction = cancelAction
+        self.secondaryButtonText = secondaryButtonText
+        self.secondaryAction = secondaryAction
         self.supplementaryContent = nil
         self._viewModel = StateObject(wrappedValue: FormInputViewModel(action: action))
     }
@@ -59,9 +64,9 @@ struct FormInput<Content: View,
                 supplementaryContent
             }
 
-            if let cancelAction = cancelAction,
+            if let secondaryAction = secondaryAction,
                !viewModel.showLoading {
-                Button("Cancel", action: cancelAction)
+                Button(secondaryButtonText, action: secondaryAction)
                     .foregroundColor(.gray)
                     .padding(.top, 8)
             }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -4,18 +4,36 @@ import XCTest
 final class ChargeCardViewModelTests: PSTestCase {
 
     var serviceUnderTest: ChargeCardViewModel!
-    var mockAmountCurrency = AmountCurrency(amount: 10000, currency: "USD")
+    var mockTransactionDetails = VerifyAccessCode.example
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        serviceUnderTest = ChargeCardViewModel(amountDetails: mockAmountCurrency)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: mockTransactionDetails)
     }
 
     func testRestartCardPaymentResetsStateToCardDetailsWithAmount() {
         serviceUnderTest.chargeCardState = .pin
         serviceUnderTest.restartCardPayment()
         XCTAssertEqual(serviceUnderTest.chargeCardState,
-            .cardDetails(amount: mockAmountCurrency))
+                       .cardDetails(amount: mockTransactionDetails.amountCurrency))
+    }
+
+    func testInitialStateIsSetToCardDetailsInLiveMode() {
+        let transactionDetails: VerifyAccessCode = .init(amount: 10000,
+                                                         currency: "USD",
+                                                         paymentChannels: [], domain: .live)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+            .cardDetails(amount: transactionDetails.amountCurrency))
+    }
+
+    func testInitialStateIsSetToTestModeCardSelectionInTestMode() {
+        let transactionDetails: VerifyAccessCode = .init(amount: 10000,
+                                                         currency: "USD",
+                                                         paymentChannels: [], domain: .test)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+                       .testModeCardSelection(amount: transactionDetails.amountCurrency))
     }
 
 }
@@ -25,8 +43,20 @@ extension ChargeCardState: Equatable {
         switch (lhs, rhs) {
         case (.cardDetails(let first), .cardDetails(let second)):
             return first == second
+        case (.testModeCardSelection(let first), testModeCardSelection(let second)):
+            return first == second
         case (.pin, .pin):
             return true
+        case (.phoneNumber, .phoneNumber):
+            return true
+        case (.otp(let first), .otp(let second)):
+            return first == second
+        case (.address(let first), .address(let second)):
+            return first == second
+        case (.birthday, .birthday):
+            return true
+        case (.error(let first), .error(let second)):
+            return first == second
         default:
             return false
         }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
@@ -16,10 +16,9 @@ final class ChargeViewModelTests: PSTestCase {
         let verifyAccessCodeResponse = VerifyAccessCode(amount: 100, currency: "USD",
                                                                 paymentChannels: ["card"], domain: .test)
         mockRepo.expectedVerifyAccessCode = verifyAccessCodeResponse
-        let expectedAmountCurrency = AmountCurrency(amount: 100, currency: "USD")
         await serviceUnderTest.verifyAccessCodeAndProceedWithCard()
         XCTAssertEqual(serviceUnderTest.transactionState,
-                       .payment(type: .card(amountInformation: expectedAmountCurrency)))
+                       .payment(type: .card(transactionInformation: verifyAccessCodeResponse)))
     }
 
     func testVerifyAccessCodeSetsViewStateAsErrorWhenUnsuccessful() async {

--- a/Tests/PaystackSDKTests/UI/Charge/TestMode/TestModeCardSelectionViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/TestMode/TestModeCardSelectionViewModelTests.swift
@@ -23,4 +23,9 @@ final class TestModeCardSelectionViewModelTests: XCTestCase {
         serviceUnderTest.testCard = nil
         XCTAssertFalse(serviceUnderTest.isValid)
     }
+
+    func testUseManualCardEntryCallsContainerToSwitchToCardDetailsFlow() {
+        serviceUnderTest.displayManualCardDetailsEntry()
+        XCTAssertTrue(mockChargeCardContainer.cardPaymentRestarted)
+    }
 }


### PR DESCRIPTION
# Changes:
- Refactored `FormInput` to rename the parameter for the action and to allow the button text to be customized
- Made changes throughout views that used the above
- Modified `ChargeCardViewModel` and view to take in the parent object `VerifyAccessCode` instead of just amount details which are needed.
- Made changes throughout previews that used the above
- Added an `example` extension on `VerifyAccessCode` to reduce duplication
-  Added `displayManualCardDetailsEntry` to `TestModeCardSelectionViewModel` to allow for switching between card entry types in test mode
- 
- Added unit tests

# Notes:
Apologies for the number of files, however, most of them are simple name and parameter type changes and should be easy to look at