### PR TITLE
Switch to test cards from card details

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
@@ -33,7 +33,11 @@ struct CardDetailsView: View {
 
             FormInput(title: viewModel.buttonTitle,
                       enabled: viewModel.isValid,
-                      action: viewModel.submitCardDetails) {
+                      action: viewModel.submitCardDetails,
+                      secondaryButtonText: viewModel.chargeCardContainer.inTestMode ?
+                      "Use a test card" : "",
+                      secondaryAction: viewModel.chargeCardContainer.inTestMode ?
+                      viewModel.switchToTestModeCardSelection : nil) {
                 cardNumber
 
                 HorizontallyGroupedFormInputItemView {

--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsViewModel.swift
@@ -57,4 +57,8 @@ class CardDetailsViewModel: ObservableObject {
     func submitCardDetails(onComplete: @escaping () -> Void) {
         // TODO: Perform API call with card details
     }
+
+    func switchToTestModeCardSelection() {
+        chargeCardContainer.switchToTestModeCardSelection()
+    }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardContainer.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardContainer.swift
@@ -1,5 +1,7 @@
 import Foundation
 
 protocol ChargeCardContainer {
+    var inTestMode: Bool { get }
     func restartCardPayment()
+    func switchToTestModeCardSelection()
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -15,7 +15,15 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
             .testModeCardSelection(amount: amountDetails)
     }
 
+    var inTestMode: Bool {
+        transactionDetails.domain == .test
+    }
+
     func restartCardPayment() {
         chargeCardState = .cardDetails(amount: transactionDetails.amountCurrency)
+    }
+
+    func switchToTestModeCardSelection() {
+        chargeCardState = .testModeCardSelection(amount: transactionDetails.amountCurrency)
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardDetails/CardDetailsViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardDetails/CardDetailsViewModelTests.swift
@@ -74,4 +74,9 @@ final class CardDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(serviceUnderTest.isValid)
     }
 
+    func testSwitchingToTestModeCardSelectionCallsContainerToChangeState() {
+        serviceUnderTest.switchToTestModeCardSelection()
+        XCTAssertTrue(mockChargeCardContainer.switchedToTestMode)
+    }
+
 }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -36,6 +36,30 @@ final class ChargeCardViewModelTests: PSTestCase {
                        .testModeCardSelection(amount: transactionDetails.amountCurrency))
     }
 
+    func testInTestModeReturnsTrueIfDomainIsTest() {
+        let transactionDetails: VerifyAccessCode = .init(amount: 10000,
+                                                         currency: "USD",
+                                                         paymentChannels: [], domain: .test)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
+        XCTAssertTrue(serviceUnderTest.inTestMode)
+    }
+
+    func testInTestModeReturnsFalseIfDomainIsLive() {
+        let transactionDetails: VerifyAccessCode = .init(amount: 10000,
+                                                         currency: "USD",
+                                                         paymentChannels: [], domain: .live)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
+        XCTAssertFalse(serviceUnderTest.inTestMode)
+    }
+
+    func testSwitchToTestModeCardSelectionChangesState() {
+        let transactionDetails: VerifyAccessCode = .init(amount: 10000,
+                                                         currency: "USD",
+                                                         paymentChannels: [], domain: .live)
+        serviceUnderTest.switchToTestModeCardSelection()
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+                       .testModeCardSelection(amount: transactionDetails.amountCurrency))
+    }
 }
 
 extension ChargeCardState: Equatable {

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardContainer.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardContainer.swift
@@ -4,9 +4,15 @@ import Foundation
 class MockChargeCardContainer: ChargeCardContainer {
 
     var cardPaymentRestarted = false
+    var inTestMode = false
+    var switchedToTestMode = false
 
     func restartCardPayment() {
         cardPaymentRestarted = true
+    }
+
+    func switchToTestModeCardSelection() {
+        switchedToTestMode = true
     }
 
 }


### PR DESCRIPTION
# Changes:
- Added fields to `ChargeCardContainer` protocol to allow for further interaction with the container
- Applied the changes required by the protocol above to change the view state accordingly 
- Modified `CardDetailsView` to display an option to switch to test card selection when the user is in test mode
- Added unit tests

# Visuals:
![Simulator Screen Recording - iPhone 14 Pro - 2023-08-10 at 14 45 30](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/983f956e-e734-4898-87c6-a5120fef472d)

