### PR TITLE
Display different error view options for test mode

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -40,8 +40,10 @@ struct ChargeCardView: View {
 
         case .error(let error):
             ErrorView(message: error.message,
-                      buttonText: "Try another card",
-                      buttonAction: viewModel.restartCardPayment)
+                      buttonText: viewModel.inTestMode ?
+                      "Retry with test details" : "Try another card",
+                      buttonAction: viewModel.inTestMode ?
+                      viewModel.switchToTestModeCardSelection : viewModel.restartCardPayment)
         }
     }
 


### PR DESCRIPTION
# Changes:
Super simple stuff.
When the payment is initiated in test mode, we modify the error view for cards to display a different option, specifically to go back to test card selection

# Visuals:
![Simulator Screen Recording - iPhone 14 Pro - 2023-08-11 at 14 01 44](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/904f9eb6-cce0-4a1e-851a-8ead2350c502)