### PR TITLE
Added model for Charge response & refactored FormInput action

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressViewModel.swift
@@ -30,7 +30,7 @@ class CardAddressViewModel: ObservableObject {
         state != nil
     }
 
-    func submitAddress(onComplete: @escaping () -> Void) {
+    func submitAddress() async {
         // TODO: Perform API call
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
@@ -22,7 +22,7 @@ class CardBirthdayViewModel: ObservableObject {
         month != nil
     }
 
-    func submitPhoneNumber(onComplete: @escaping () -> Void) {
+    func submitPhoneNumber() async {
         // TODO: Perform API call to submit birthday
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsViewModel.swift
@@ -54,7 +54,7 @@ class CardDetailsViewModel: ObservableObject {
         }
     }
 
-    func submitCardDetails(onComplete: @escaping () -> Void) {
+    func submitCardDetails() async {
         // TODO: Perform API call with card details
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardTransaction.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardTransaction.swift
@@ -1,0 +1,28 @@
+import Foundation
+import PaystackCore
+
+// TODO: Add further fields here once we know what is required
+struct ChargeCardTransaction {
+    var status: TransactionStatus
+    var redirectUrl: String?
+    var customerPhone: String?
+    var countryCode: String?
+}
+
+extension ChargeCardTransaction {
+
+    static func from(_ response: ChargeResponse) -> Self {
+        ChargeCardTransaction(status: response.data.status,
+                              redirectUrl: response.data.redirectUrl,
+                              customerPhone: response.data.customer?.phone,
+                              countryCode: response.data.authorization?.countryCode)
+    }
+
+}
+
+// MARK: - Previews
+extension ChargeCardTransaction {
+    static var example: Self {
+        .init(status: .success)
+    }
+}

--- a/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPViewModel.swift
@@ -26,7 +26,7 @@ class CardOTPViewModel: ObservableObject {
         !otp.removingAllWhitespaces.isEmpty
     }
 
-    func submitOTP(onComplete: @escaping () -> Void) {
+    func submitOTP() async {
         // TODO: Perform API call
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneViewModel.swift
@@ -15,7 +15,7 @@ class CardPhoneViewModel: ObservableObject {
         phoneNumber.count >= 10
     }
 
-    func submitPhoneNumber(onComplete: @escaping () -> Void) {
+    func submitPhoneNumber() async {
         // TODO: Perform API call to submit phone number
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionViewModel.swift
@@ -22,7 +22,7 @@ class TestModeCardSelectionViewModel: ObservableObject {
         testCard != nil
     }
 
-    func proceedWithTestCard(onComplete: @escaping () -> Void) {
+    func proceedWithTestCard() async {
         // TODO: Perform API call with card details
     }
 

--- a/Sources/PaystackUI/Components/Form/FormInput.swift
+++ b/Sources/PaystackUI/Components/Form/FormInput.swift
@@ -16,7 +16,7 @@ struct FormInput<Content: View,
 
     init(title: String = "Submit",
          enabled: Bool = true,
-         action: @escaping (@escaping () -> Void) -> Void,
+         action: @escaping () async -> Void,
          secondaryButtonText: String = "Cancel",
          secondaryAction: (() -> Void)? = nil,
          supplementaryContent: SupplementaryContent,
@@ -33,7 +33,7 @@ struct FormInput<Content: View,
 
     init(title: String = "Submit",
          enabled: Bool = true,
-         action: @escaping (@escaping () -> Void) -> Void,
+         action: @escaping () async -> Void,
          secondaryButtonText: String = "Cancel",
          secondaryAction: (() -> Void)? = nil,
          @FormInputDataBuilder content: () -> FormInputData<Content>)
@@ -76,7 +76,9 @@ struct FormInput<Content: View,
 
     func submit() {
         guard formData.validate() else { return }
-        viewModel.submit()
+        Task {
+            await viewModel.submit()
+        }
     }
 
 }
@@ -96,12 +98,13 @@ struct FormInput_Previews: PreviewProvider {
         @State
         var status: String = ""
 
+        func complete() async {
+            status = "Complete"
+        }
+
         var body: some View {
             VStack {
-                FormInput { onComplete in
-                    status = "Complete"
-                    onComplete()
-                } content: {
+                FormInput(action: complete) {
                     TextField("Name", text: $name)
                         .form("Name")
 

--- a/Sources/PaystackUI/Components/Form/FormInputViewModel.swift
+++ b/Sources/PaystackUI/Components/Form/FormInputViewModel.swift
@@ -5,17 +5,16 @@ class FormInputViewModel: ObservableObject {
     @Published
     var showLoading = false
 
-    var action: (@escaping () -> Void) -> Void
+    var action: () async -> Void
 
-    init(action: @escaping (@escaping () -> Void) -> Void) {
+    init(action: @escaping () async -> Void) {
         self.action = action
     }
 
-    func submit() {
+    func submit() async {
         showLoading = true
-        action { [self] in
-            showLoading = false
-        }
+        await action()
+        showLoading = false
     }
 
 }


### PR DESCRIPTION
Since this was a small change needed for the charge model I've added in an improvement I've been meaning to make.

# Changes:
- Added in `ChargeCardTransaction` which acts as a simplified version of the `ChargeResponse` and only gives us what we need for our flows. Will be used in the upcoming PRs
- Modified `FormInput` and its view model so that we can simplify the functions to use async await only which is significantly cleaner and lets us keep `Task`s out of the view model as well
- Updated all the view models that use the above as necessary
