### PR TITLE
Renamed request models

### DIFF
--- a/Sources/PaystackSDK/API/Charge/Charge.swift
+++ b/Sources/PaystackSDK/API/Charge/Charge.swift
@@ -8,53 +8,53 @@ public extension Paystack {
     /// Continues the Charge flow by authenticating a user with an OTP
     /// - Parameters:
     ///   - otp: The OTP sent to the user's device
-    ///   - reference: The reference of the current transaction
+    ///   - accessCode: The access code for the current transaction
     /// - Returns: A ``Service`` with the results of the authentication
-    func authenticateCharge(withOtp otp: String, reference: String) -> Service<ChargeResponse> {
-        let request = SubmitOtpRequest(otp: otp, reference: reference)
+    func authenticateCharge(withOtp otp: String, accessCode: String) -> Service<ChargeResponse> {
+        let request = SubmitOtpRequest(otp: otp, accessCode: accessCode)
         return service.postSubmitOtp(request)
     }
 
     /// Continues the Charge flow by authenticating a user with a Pin
     /// - Parameters:
     ///   - pin: The user's card pin
-    ///   - reference: The reference of the current transaction
+    ///   - accessCode: The access code for the current transaction
     /// - Returns: A ``Service`` with the results of the authentication
-    func authenticateCharge(withPin pin: String, reference: String) -> Service<ChargeResponse> {
-        let request = SubmitPinRequest(pin: pin, reference: reference)
+    func authenticateCharge(withPin pin: String, accessCode: String) -> Service<ChargeResponse> {
+        let request = SubmitPinRequest(pin: pin, accessCode: accessCode)
         return service.postSubmitPin(request)
     }
 
     /// Continues the Charge flow by authenticating a user with a phone number
     /// - Parameters:
     ///   - phone: The user's phone number associated with the card
-    ///   - reference: The reference of the current transaction
+    ///   - accessCode: The access code for the current transaction
     /// - Returns: A ``Service`` with the results of the authentication
     func authenticateCharge(withPhone phone: String,
-                            reference: String) -> Service<ChargeResponse> {
-        let request = SubmitPhoneRequest(phone: phone, reference: reference)
+                            accessCode: String) -> Service<ChargeResponse> {
+        let request = SubmitPhoneRequest(phone: phone, accessCode: accessCode)
         return service.postSubmitPhone(request)
     }
 
     /// Continues the Charge flow by authenticating a user with their birthday
     /// - Parameters:
     ///   - birthday: The user's birthday in ISO 8601 format
-    ///   - reference: The reference of the current transaction
+    ///   - accessCode: The access code for the current transaction
     /// - Returns: A ``Service`` with the results of the authentication
     func authenticateCharge(withBirthday birthday: String,
-                            reference: String) -> Service<ChargeResponse> {
-        let request = SubmitBirthdayRequest(birthday: birthday, reference: reference)
+                            accessCode: String) -> Service<ChargeResponse> {
+        let request = SubmitBirthdayRequest(birthday: birthday, accessCode: accessCode)
         return service.postSubmitBirthday(request)
     }
 
     /// Continues the Charge flow by authenticating a user with their address
     /// - Parameters:
     ///   - address: An ``Address`` object describing the user's address
-    ///   - reference: The reference of the current transaction
+    ///   - accessCode: The access code for the current transaction
     /// - Returns: A ``Service`` with the results of the authentication
     func authenticateCharge(withAddress address: Address,
-                            reference: String) -> Service<ChargeResponse> {
-        let request = SubmitAddressRequest(address: address, reference: reference)
+                            accessCode: String) -> Service<ChargeResponse> {
+        let request = SubmitAddressRequest(address: address, accessCode: accessCode)
         return service.postSubmitAddress(request)
     }
 

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitAddressRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitAddressRequest.swift
@@ -5,18 +5,13 @@ struct SubmitAddressRequest: Codable {
     var city: String
     var state: String
     var zipCode: String
-    var reference: String
+    var accessCode: String
 
-    init(address: Address, reference: String) {
+    init(address: Address, accessCode: String) {
         self.address = address.address
         self.city = address.city
         self.state = address.state
         self.zipCode = address.zipCode
-        self.reference = reference
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case address, city, state, reference
-        case zipCode = "zip_code"
+        self.accessCode = accessCode
     }
 }

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitBirthdayRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitBirthdayRequest.swift
@@ -2,5 +2,5 @@ import Foundation
 
 struct SubmitBirthdayRequest: Codable {
     var birthday: String
-    var reference: String
+    var accessCode: String
 }

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitOtpRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitOtpRequest.swift
@@ -2,5 +2,5 @@ import Foundation
 
 struct SubmitOtpRequest: Codable {
     var otp: String
-    var reference: String
+    var accessCode: String
 }

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitPhoneRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitPhoneRequest.swift
@@ -2,5 +2,5 @@ import Foundation
 
 struct SubmitPhoneRequest: Codable {
     var phone: String
-    var reference: String
+    var accessCode: String
 }

--- a/Sources/PaystackSDK/Core/Models/Models/SubmitPinRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/SubmitPinRequest.swift
@@ -2,5 +2,5 @@ import Foundation
 
 struct SubmitPinRequest: Codable {
     var pin: String
-    var reference: String
+    var accessCode: String
 }

--- a/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
+++ b/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
@@ -15,7 +15,7 @@ final class ChargeTests: PSTestCase {
     }
 
     func testAuthenticateChargeWithOTPAuthentication() throws {
-        let otpRequestBody = SubmitOtpRequest(otp: "12345", reference: "abcde")
+        let otpRequestBody = SubmitOtpRequest(otp: "12345", accessCode: "abcde")
 
         mockServiceExecutor
             .expectURL("https://api.paystack.co/charge/submit_otp")
@@ -24,11 +24,11 @@ final class ChargeTests: PSTestCase {
             .expectBody(otpRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(withOtp: "12345", reference: "abcde").sync()
+        _ = try serviceUnderTest.authenticateCharge(withOtp: "12345", accessCode: "abcde").sync()
     }
 
     func testAuthenticateChargeWithPinAuthentication() throws {
-        let pinRequestBody = SubmitPinRequest(pin: "1234", reference: "abcde")
+        let pinRequestBody = SubmitPinRequest(pin: "1234", accessCode: "abcde")
 
         mockServiceExecutor
             .expectURL("https://api.paystack.co/charge/submit_pin")
@@ -37,11 +37,11 @@ final class ChargeTests: PSTestCase {
             .expectBody(pinRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(withPin: "1234", reference: "abcde").sync()
+        _ = try serviceUnderTest.authenticateCharge(withPin: "1234", accessCode: "abcde").sync()
     }
 
     func testAuthenticateChargeWithPhoneAuthentication() throws {
-        let phoneRequestBody = SubmitPhoneRequest(phone: "0111234567", reference: "abcde")
+        let phoneRequestBody = SubmitPhoneRequest(phone: "0111234567", accessCode: "abcde")
 
         mockServiceExecutor
             .expectURL("https://api.paystack.co/charge/submit_phone")
@@ -50,11 +50,11 @@ final class ChargeTests: PSTestCase {
             .expectBody(phoneRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(withPhone: "0111234567", reference: "abcde").sync()
+        _ = try serviceUnderTest.authenticateCharge(withPhone: "0111234567", accessCode: "abcde").sync()
     }
 
     func testAuthenticateChargeWithBirthdayAuthentication() throws {
-        let birthdayRequestBody = SubmitBirthdayRequest(birthday: "1990-01-01", reference: "abcde")
+        let birthdayRequestBody = SubmitBirthdayRequest(birthday: "1990-01-01", accessCode: "abcde")
 
         mockServiceExecutor
             .expectURL("https://api.paystack.co/charge/submit_birthday")
@@ -63,14 +63,14 @@ final class ChargeTests: PSTestCase {
             .expectBody(birthdayRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(withBirthday: "1990-01-01", reference: "abcde").sync()
+        _ = try serviceUnderTest.authenticateCharge(withBirthday: "1990-01-01", accessCode: "abcde").sync()
     }
 
     func testAuthenticateChargeWithAddressAuthentication() throws {
         let address = Address(address: "123 Road", city: "Johannesburg",
                               state: "Gauteng", zipCode: "1234")
         let addressRequestBody = SubmitAddressRequest(address: address,
-                                                      reference: "abcde")
+                                                      accessCode: "abcde")
 
         mockServiceExecutor
             .expectURL("https://api.paystack.co/charge/submit_address")
@@ -79,7 +79,7 @@ final class ChargeTests: PSTestCase {
             .expectBody(addressRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(withAddress: address, reference: "abcde").sync()
+        _ = try serviceUnderTest.authenticateCharge(withAddress: address, accessCode: "abcde").sync()
     }
 
     func testListenFor3DS() throws {


### PR DESCRIPTION
 # Changes:
Pretty small change here. Renaming the request models and associated parameters to use `accessCode` instead of the previous `reference`