### PR TITLE
Added logic for submitting birthday

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 class CardBirthdayViewModel: ObservableObject {
     var chargeCardContainer: ChargeCardContainer
+    var repository: ChargeCardRepository
 
     @Published
     var day: String = ""
@@ -12,8 +13,10 @@ class CardBirthdayViewModel: ObservableObject {
     @Published
     var year: String = ""
 
-    init(chargeCardContainer: ChargeCardContainer) {
+    init(chargeCardContainer: ChargeCardContainer,
+         repository: ChargeCardRepository = ChargeCardRepositoryImplementation()) {
         self.chargeCardContainer = chargeCardContainer
+        self.repository = repository
     }
 
     var isValid: Bool {
@@ -23,7 +26,14 @@ class CardBirthdayViewModel: ObservableObject {
     }
 
     func submitPhoneNumber() async {
-        // TODO: Perform API call to submit birthday
+        do {
+            let formattedBirthday = "\(year)-\(month?.formattedRepresentation ?? "00")-\(day)"
+            let authenticationResult = try await repository.submitBirthday(
+                formattedBirthday, accessCode: chargeCardContainer.accessCode)
+            chargeCardContainer.processTransactionResponse(authenticationResult)
+        } catch {
+            // TODO: Determine error handling once we have further information
+        }
     }
 
     func cancelTransaction() {

--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/Month.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/Month.swift
@@ -42,4 +42,8 @@ enum Month: Int, CustomStringConvertible, CaseIterable {
             return "December"
         }
     }
+
+    var formattedRepresentation: String {
+        String(format: "%02d", self.rawValue)
+    }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardContainer.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardContainer.swift
@@ -2,6 +2,8 @@ import Foundation
 
 protocol ChargeCardContainer {
     var inTestMode: Bool { get }
+    var accessCode: String { get }
+    func processTransactionResponse(_ response: ChargeCardTransaction)
     func restartCardPayment()
     func switchToTestModeCardSelection()
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -15,6 +15,10 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
             .testModeCardSelection(amount: amountDetails)
     }
 
+    var accessCode: String {
+        transactionDetails.accessCode
+    }
+
     var inTestMode: Bool {
         transactionDetails.domain == .test
     }
@@ -25,5 +29,9 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
 
     func switchToTestModeCardSelection() {
         chargeCardState = .testModeCardSelection(amount: transactionDetails.amountCurrency)
+    }
+
+    func processTransactionResponse(_ response: ChargeCardTransaction) {
+        // TODO: Will handle processing the responses in a future PR
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardTransaction.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardTransaction.swift
@@ -2,7 +2,7 @@ import Foundation
 import PaystackCore
 
 // TODO: Add further fields here once we know what is required
-struct ChargeCardTransaction {
+struct ChargeCardTransaction: Equatable {
     var status: TransactionStatus
     var redirectUrl: String?
     var customerPhone: String?

--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepository.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepository.swift
@@ -1,0 +1,5 @@
+import PaystackCore
+
+protocol ChargeCardRepository {
+    func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction
+}

--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
@@ -1,0 +1,10 @@
+import PaystackCore
+
+// TODO: Make actual calls here once we finalize API mocking
+struct ChargeCardRepositoryImplementation: ChargeCardRepository {
+
+    func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction {
+        ChargeCardTransaction.example
+    }
+
+}

--- a/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
+++ b/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
@@ -4,6 +4,7 @@ import PaystackCore
 struct VerifyAccessCode: Equatable {
     var amount: Decimal
     var currency: String
+    var accessCode: String
     // TODO: Use enum once we see example responses
     var paymentChannels: [String]
     var domain: Domain
@@ -18,6 +19,7 @@ extension VerifyAccessCode {
     static func from(_ response: VerifyAccessCodeResponse) -> Self {
         VerifyAccessCode(amount: response.data.amount,
                          currency: response.data.currency,
+                         accessCode: response.data.accessCode,
                          paymentChannels: response.data.channels,
                          domain: response.data.domain)
     }
@@ -29,6 +31,7 @@ extension VerifyAccessCode {
     static var example: Self {
         .init(amount: 10000,
               currency: "USD",
+              accessCode: "test_access",
               paymentChannels: [],
               domain: .test)
     }

--- a/Tests/PaystackSDKTests/UI/Charge/CardBirthday/CardBirthdayViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardBirthday/CardBirthdayViewModelTests.swift
@@ -5,11 +5,14 @@ final class CardBirthdayViewModelTests: XCTestCase {
 
     var serviceUnderTest: CardBirthdayViewModel!
     var mockChargeCardContainer: MockChargeCardContainer!
+    var mockRepository: MockChargeCardRepository!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         mockChargeCardContainer = MockChargeCardContainer()
-        serviceUnderTest = CardBirthdayViewModel(chargeCardContainer: mockChargeCardContainer)
+        mockRepository = MockChargeCardRepository()
+        serviceUnderTest = CardBirthdayViewModel(chargeCardContainer: mockChargeCardContainer,
+                                                 repository: mockRepository)
     }
 
     func testCancelTransactionCallsContainerToRestartCardFlow() {
@@ -36,5 +39,18 @@ final class CardBirthdayViewModelTests: XCTestCase {
         serviceUnderTest.day = "01"
         serviceUnderTest.month = .january
         XCTAssertTrue(serviceUnderTest.isValid)
+    }
+
+    func testSubmittingBirthdayFormatsBirthdayCorrectlyAndSendsRepoResultToCardContainer() async throws {
+        serviceUnderTest.year = "2000"
+        serviceUnderTest.month = .january
+        serviceUnderTest.day = "01"
+
+        mockRepository.expectedChargeCardTransaction = .example
+        await serviceUnderTest.submitPhoneNumber()
+
+        let expectedBirthdayFormat = "2000-01-01"
+        XCTAssertEqual(mockRepository.birthdaySubmitted.birthday, expectedBirthdayFormat)
+        XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -21,6 +21,7 @@ final class ChargeCardViewModelTests: PSTestCase {
     func testInitialStateIsSetToCardDetailsInLiveMode() {
         let transactionDetails: VerifyAccessCode = .init(amount: 10000,
                                                          currency: "USD",
+                                                         accessCode: "test_access",
                                                          paymentChannels: [], domain: .live)
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
         XCTAssertEqual(serviceUnderTest.chargeCardState,
@@ -30,6 +31,7 @@ final class ChargeCardViewModelTests: PSTestCase {
     func testInitialStateIsSetToTestModeCardSelectionInTestMode() {
         let transactionDetails: VerifyAccessCode = .init(amount: 10000,
                                                          currency: "USD",
+                                                         accessCode: "test_access",
                                                          paymentChannels: [], domain: .test)
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
         XCTAssertEqual(serviceUnderTest.chargeCardState,
@@ -39,6 +41,7 @@ final class ChargeCardViewModelTests: PSTestCase {
     func testInTestModeReturnsTrueIfDomainIsTest() {
         let transactionDetails: VerifyAccessCode = .init(amount: 10000,
                                                          currency: "USD",
+                                                         accessCode: "test_access",
                                                          paymentChannels: [], domain: .test)
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
         XCTAssertTrue(serviceUnderTest.inTestMode)
@@ -47,6 +50,7 @@ final class ChargeCardViewModelTests: PSTestCase {
     func testInTestModeReturnsFalseIfDomainIsLive() {
         let transactionDetails: VerifyAccessCode = .init(amount: 10000,
                                                          currency: "USD",
+                                                         accessCode: "test_access",
                                                          paymentChannels: [], domain: .live)
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
         XCTAssertFalse(serviceUnderTest.inTestMode)
@@ -55,6 +59,7 @@ final class ChargeCardViewModelTests: PSTestCase {
     func testSwitchToTestModeCardSelectionChangesState() {
         let transactionDetails: VerifyAccessCode = .init(amount: 10000,
                                                          currency: "USD",
+                                                         accessCode: "test_access",
                                                          paymentChannels: [], domain: .live)
         serviceUnderTest.switchToTestModeCardSelection()
         XCTAssertEqual(serviceUnderTest.chargeCardState,

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
@@ -24,6 +24,7 @@ final class ChargeRepositoryImplementationTests: PSTestCase {
         let result = try await serviceUnderTest.verifyAccessCode("access_code_test")
         let expectedResult = VerifyAccessCode(amount: 10000,
                                               currency: "NGN",
+                                              accessCode: "Access_Code_Test",
                                               paymentChannels: ["card", "qr", "ussd"],
                                               domain: .test)
 

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
@@ -13,12 +13,10 @@ final class ChargeViewModelTests: PSTestCase {
     }
 
     func testVerifyAccessCodeSetsViewStateAsCardDetailsWhenSuccessful() async {
-        let verifyAccessCodeResponse = VerifyAccessCode(amount: 100, currency: "USD",
-                                                                paymentChannels: ["card"], domain: .test)
-        mockRepo.expectedVerifyAccessCode = verifyAccessCodeResponse
+        mockRepo.expectedVerifyAccessCode = .example
         await serviceUnderTest.verifyAccessCodeAndProceedWithCard()
         XCTAssertEqual(serviceUnderTest.transactionState,
-                       .payment(type: .card(transactionInformation: verifyAccessCodeResponse)))
+                       .payment(type: .card(transactionInformation: .example)))
     }
 
     func testVerifyAccessCodeSetsViewStateAsErrorWhenUnsuccessful() async {
@@ -47,12 +45,14 @@ final class ChargeViewModelTests: PSTestCase {
 
     func testPaymentIsInTestModeWhenDomainIsSetToTest() {
         serviceUnderTest.transactionDetails = .init(amount: 10000, currency: "USD",
+                                                    accessCode: "test_access",
                                                     paymentChannels: [], domain: .test)
         XCTAssertTrue(serviceUnderTest.inTestMode)
     }
 
     func testPaymentIsNotInTestModeWhenDomainIsSetToLive() {
         serviceUnderTest.transactionDetails = .init(amount: 10000, currency: "USD",
+                                                    accessCode: "test_access",
                                                     paymentChannels: [], domain: .live)
         XCTAssertFalse(serviceUnderTest.inTestMode)
     }

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardContainer.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardContainer.swift
@@ -5,7 +5,9 @@ class MockChargeCardContainer: ChargeCardContainer {
 
     var cardPaymentRestarted = false
     var inTestMode = false
+    var accessCode: String = "Mock_Access_Code"
     var switchedToTestMode = false
+    var transactionResponse: ChargeCardTransaction?
 
     func restartCardPayment() {
         cardPaymentRestarted = true
@@ -13,6 +15,10 @@ class MockChargeCardContainer: ChargeCardContainer {
 
     func switchToTestModeCardSelection() {
         switchedToTestMode = true
+    }
+
+    func processTransactionResponse(_ response: ChargeCardTransaction) {
+        transactionResponse = response
     }
 
 }

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardRepository.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardRepository.swift
@@ -1,0 +1,24 @@
+import Foundation
+import PaystackCore
+@testable import PaystackUI
+
+class MockChargeCardRepository: ChargeCardRepository {
+
+    var expectedChargeCardTransaction: ChargeCardTransaction?
+    var expectedErrorResponse: Error?
+
+    var birthdaySubmitted: (birthday: String, accessCode: String) = ("", "")
+
+    func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction {
+        birthdaySubmitted = (birthday, accessCode)
+        return try await mockedResponse()
+    }
+
+    private func mockedResponse() async throws -> ChargeCardTransaction {
+        guard let response = expectedChargeCardTransaction else {
+            throw expectedErrorResponse ?? MockError.stubNotProvided
+        }
+        return response
+    }
+
+}


### PR DESCRIPTION
# Changes:
- Added `formattedRepresentation` to the `Month` enum to get month formatted with leading zeros when necessary
- Created `ChargeCardRepository` and an implementation for it that currently returns static data
- Added `accessCode` as a variable to `VerifyAccessCode`
- Updated `ChargeCardContainer` to provide the access code as well as be able to process responses
- Added logic to `CardBirthdayViewModel` to format the birthday, send a request to the repository and send the response to the charge card container
- Updated tests and mocks to cater to changes
- Added new unit tests for logic for submitting birthday