### PR TITLE
Create Charge container and integrate with charge card

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressView.swift
@@ -74,6 +74,7 @@ struct CardAddressView_Previews: PreviewProvider {
     static var previews: some View {
         CardAddressView(states: [],
                         chargeCardContainer: ChargeCardViewModel(
-                            transactionDetails: .example))
+                            transactionDetails: .example,
+                            chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayView.swift
@@ -77,6 +77,7 @@ struct CardBirthdayView: View {
 struct CardBirthdayView_Previews: PreviewProvider {
     static var previews: some View {
         CardBirthdayView(chargeCardContainer: ChargeCardViewModel(
-            transactionDetails: .example))
+            transactionDetails: .example,
+            chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
@@ -101,6 +101,7 @@ struct CardDetailsView_Previews: PreviewProvider {
             amountDetails: .init(amount: 10000,
                                  currency: "USD"),
             chargeCardContainer: ChargeCardViewModel(
-                transactionDetails: .example))
+                transactionDetails: .example,
+                chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -6,9 +6,10 @@ struct ChargeCardView: View {
     @StateObject
     var viewModel: ChargeCardViewModel
 
-    init(transactionDetails: VerifyAccessCode) {
+    init(transactionDetails: VerifyAccessCode, chargeContainer: ChargeContainer) {
         self._viewModel = StateObject(
-            wrappedValue: ChargeCardViewModel(transactionDetails: transactionDetails))
+            wrappedValue: ChargeCardViewModel(transactionDetails: transactionDetails,
+                                              chargeContainer: chargeContainer))
     }
 
     var body: some View {

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -6,9 +6,12 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
     var chargeCardState: ChargeCardState
 
     var transactionDetails: VerifyAccessCode
+    var chargeContainer: ChargeContainer
 
-    init(transactionDetails: VerifyAccessCode) {
+    init(transactionDetails: VerifyAccessCode,
+         chargeContainer: ChargeContainer) {
         self.transactionDetails = transactionDetails
+        self.chargeContainer = chargeContainer
         let amountDetails = transactionDetails.amountCurrency
         self.chargeCardState = transactionDetails.domain == .live ?
             .cardDetails(amount: amountDetails) :

--- a/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPVIew.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPVIew.swift
@@ -88,6 +88,7 @@ struct CardOTPVIew_Previews: PreviewProvider {
     static var previews: some View {
         CardOTPVIew(phoneNumber: "+234801****5678",
                     chargeCardContainer: ChargeCardViewModel(
-                        transactionDetails: .example))
+                        transactionDetails: .example,
+                        chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneView.swift
@@ -52,6 +52,7 @@ struct CardPhoneView: View {
 struct CardPhoneView_Previews: PreviewProvider {
     static var previews: some View {
         CardPhoneView(chargeCardContainer: ChargeCardViewModel(
-            transactionDetails: .example))
+            transactionDetails: .example,
+            chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinView.swift
@@ -51,6 +51,7 @@ struct CardPinView: View {
 struct CardPinView_Previews: PreviewProvider {
     static var previews: some View {
         CardPinView(chargeCardContainer: ChargeCardViewModel(
-            transactionDetails: .example))
+            transactionDetails: .example,
+            chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionView.swift
@@ -60,6 +60,7 @@ struct TestModeCardSelectionView_Previews: PreviewProvider {
             amountDetails: .init(amount: 10000,
                                  currency: "USD"),
             chargeCardContainer: ChargeCardViewModel(
-                transactionDetails: .example))
+                transactionDetails: .example,
+                chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeContainer.swift
+++ b/Sources/PaystackUI/Charge/ChargeContainer.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol ChargeContainer {
+    func processSuccessfulTransaction(details: VerifyAccessCode)
+    func processFailedTransaction()
+}

--- a/Sources/PaystackUI/Charge/ChargeView.swift
+++ b/Sources/PaystackUI/Charge/ChargeView.swift
@@ -12,9 +12,7 @@ struct ChargeView: View {
 
     init(accessCode: String) {
         self._viewModel = StateObject(
-            wrappedValue: ChargeViewModel(
-                accessCode: accessCode,
-                repository: ChargeRepositoryImplementation()))
+            wrappedValue: ChargeViewModel(accessCode: accessCode))
     }
 
     var body: some View {
@@ -31,7 +29,7 @@ struct ChargeView: View {
             case .loading(let message):
                 LoadingView(message: message)
             case .error:
-                Text("TODO")
+                Text("Something went wrong")
             case .payment(let type):
                 paymentFlowView(for: type)
             case .success(let amount, let merchant):
@@ -53,7 +51,8 @@ struct ChargeView: View {
     func paymentFlowView(for type: ChargePaymentType) -> some View {
         switch type {
         case .card(let transactionInformation):
-            ChargeCardView(transactionDetails: transactionInformation)
+            ChargeCardView(transactionDetails: transactionInformation,
+                           chargeContainer: viewModel)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeViewModel.swift
@@ -12,7 +12,7 @@ class ChargeViewModel: ObservableObject {
     var transactionDetails: VerifyAccessCode?
 
     init(accessCode: String,
-         repository: ChargeRepository) {
+         repository: ChargeRepository = ChargeRepositoryImplementation()) {
         self.accessCode = accessCode
         self.repository = repository
     }
@@ -27,6 +27,19 @@ class ChargeViewModel: ObservableObject {
         } catch {
             transactionState = .error(error)
         }
+    }
+
+}
+
+// MARK: - Charge Container
+extension ChargeViewModel: ChargeContainer {
+
+    func processSuccessfulTransaction(details: VerifyAccessCode) {
+        transactionState = .success(amount: details.amountCurrency, merchant: details.merchantName)
+    }
+
+    func processFailedTransaction() {
+        // TODO: Will handle in another PR
     }
 
 }

--- a/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
+++ b/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
@@ -8,6 +8,7 @@ struct VerifyAccessCode: Equatable {
     // TODO: Use enum once we see example responses
     var paymentChannels: [String]
     var domain: Domain
+    var merchantName: String
     var publicEncryptionKey: String
 
     var amountCurrency: AmountCurrency {
@@ -23,6 +24,7 @@ extension VerifyAccessCode {
                          accessCode: response.data.accessCode,
                          paymentChannels: response.data.channels,
                          domain: response.data.domain,
+                         merchantName: response.data.merchantName,
                          publicEncryptionKey: response.data.publicEncryptionKey)
     }
 
@@ -36,6 +38,7 @@ extension VerifyAccessCode {
               accessCode: "test_access",
               paymentChannels: [],
               domain: .test,
+              merchantName: "Test Merchant",
               publicEncryptionKey: "test_encryption_key")
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -5,10 +5,13 @@ final class ChargeCardViewModelTests: PSTestCase {
 
     var serviceUnderTest: ChargeCardViewModel!
     var mockTransactionDetails = VerifyAccessCode.example
+    var mockChargeContainer: MockChargeContainer!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        serviceUnderTest = ChargeCardViewModel(transactionDetails: mockTransactionDetails)
+        mockChargeContainer = MockChargeContainer()
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: mockTransactionDetails,
+                                               chargeContainer: mockChargeContainer)
     }
 
     func testRestartCardPaymentResetsStateToCardDetailsWithAmount() {
@@ -23,8 +26,10 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          currency: "USD",
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .live,
+                                                         merchantName: "Test Merchant",
                                                          publicEncryptionKey: "test_encryption_key")
-        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
+                                               chargeContainer: mockChargeContainer)
         XCTAssertEqual(serviceUnderTest.chargeCardState,
             .cardDetails(amount: transactionDetails.amountCurrency))
     }
@@ -34,8 +39,10 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          currency: "USD",
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .test,
+                                                         merchantName: "Test Merchant",
                                                          publicEncryptionKey: "test_encryption_key")
-        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
+                                               chargeContainer: mockChargeContainer)
         XCTAssertEqual(serviceUnderTest.chargeCardState,
                        .testModeCardSelection(amount: transactionDetails.amountCurrency))
     }
@@ -45,8 +52,10 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          currency: "USD",
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .test,
+                                                         merchantName: "Test Merchant",
                                                          publicEncryptionKey: "test_encryption_key")
-        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
+                                               chargeContainer: mockChargeContainer)
         XCTAssertTrue(serviceUnderTest.inTestMode)
     }
 
@@ -55,8 +64,10 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          currency: "USD",
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .live,
+                                                         merchantName: "Test Merchant",
                                                          publicEncryptionKey: "test_encryption_key")
-        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails)
+        serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
+                                               chargeContainer: mockChargeContainer)
         XCTAssertFalse(serviceUnderTest.inTestMode)
     }
 
@@ -65,6 +76,7 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          currency: "USD",
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .live,
+                                                         merchantName: "Test Merchant",
                                                          publicEncryptionKey: "test_encryption_key")
         serviceUnderTest.switchToTestModeCardSelection()
         XCTAssertEqual(serviceUnderTest.chargeCardState,

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
@@ -28,6 +28,7 @@ final class ChargeRepositoryImplementationTests: PSTestCase {
                                               accessCode: "Access_Code_Test",
                                               paymentChannels: ["card", "qr", "ussd"],
                                               domain: .test,
+                                              merchantName: "Test Merchant",
                                               publicEncryptionKey: "test_encryption_key")
 
         XCTAssertEqual(result, expectedResult)

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
@@ -47,6 +47,7 @@ final class ChargeViewModelTests: PSTestCase {
         serviceUnderTest.transactionDetails = .init(amount: 10000, currency: "USD",
                                                     accessCode: "test_access",
                                                     paymentChannels: [], domain: .test,
+                                                    merchantName: "Test Merchant",
                                                     publicEncryptionKey: "test_encryption_key")
         XCTAssertTrue(serviceUnderTest.inTestMode)
     }
@@ -55,6 +56,7 @@ final class ChargeViewModelTests: PSTestCase {
         serviceUnderTest.transactionDetails = .init(amount: 10000, currency: "USD",
                                                     accessCode: "test_access",
                                                     paymentChannels: [], domain: .live,
+                                                    merchantName: "Test Merchant",
                                                     publicEncryptionKey: "test_encryption_key")
         XCTAssertFalse(serviceUnderTest.inTestMode)
     }

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeContainer.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeContainer.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import PaystackUI
+
+class MockChargeContainer: ChargeContainer {
+    var transactionSuccessful = false
+    var transactionFailed = false
+
+    func processSuccessfulTransaction(details: VerifyAccessCode) {
+        transactionSuccessful = true
+    }
+
+    func processFailedTransaction() {
+        transactionFailed = true
+    }
+
+}


### PR DESCRIPTION
# Notes:
The focus here is creating the `ChargeContainer` which is implemented by the existing `ChargeViewModel`. This will be used as the interface for the respective payment channel containers to communicate success and failure responses

# Changes:
A lot of repetition here, aside from creating the above, had to modify the places where these were used currently
Also added merchantName as part of VerifyAcessCode model one time, because why not