### PR TITLE
Modifying transaction state based on transaction status

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -34,7 +34,38 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
         chargeCardState = .testModeCardSelection(amount: transactionDetails.amountCurrency)
     }
 
+    @MainActor
     func processTransactionResponse(_ response: ChargeCardTransaction) {
-        // TODO: Will handle processing the responses in a future PR
+        switch response.status {
+        case .sendAddress:
+            // TODO: Fetch states from API
+            let mockStates = ["Test State A", "Test State B"]
+            chargeCardState = .address(states: mockStates)
+        case .sendBirthday:
+            chargeCardState = .birthday
+        case .sendPhone:
+            chargeCardState = .phoneNumber
+        case .sendOtp:
+            if let phoneNumber = response.customerPhone {
+                chargeCardState = .otp(phoneNumber: phoneNumber)
+            } else {
+                // TODO: Display error
+            }
+        case .sendPin:
+            chargeCardState = .pin
+        case .success:
+            chargeContainer.processSuccessfulTransaction(details: transactionDetails)
+        case .failed:
+            chargeContainer.processFailedTransaction()
+        case .pending:
+            // TODO: Add logic for pending state
+            break
+        case .redirect:
+            // TODO: Add logic for 3DS
+            break
+        case .timeout:
+            // TODO: Add logic for timeout
+            break
+        }
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -82,6 +82,50 @@ final class ChargeCardViewModelTests: PSTestCase {
         XCTAssertEqual(serviceUnderTest.chargeCardState,
                        .testModeCardSelection(amount: transactionDetails.amountCurrency))
     }
+
+    func testProcessResponseWithAddressStatusSetsStateToAddress() async {
+        let addressResponse = ChargeCardTransaction(status: .sendAddress)
+        let mockStates = ["Test State A", "Test State B"]
+        await serviceUnderTest.processTransactionResponse(addressResponse)
+        XCTAssertEqual(serviceUnderTest.chargeCardState, .address(states: mockStates))
+    }
+
+    func testProcessResponseWithBirthdayStatusSetsStateToBirthday() async {
+        let birthdayResponse = ChargeCardTransaction(status: .sendBirthday)
+        await serviceUnderTest.processTransactionResponse(birthdayResponse)
+        XCTAssertEqual(serviceUnderTest.chargeCardState, .birthday)
+    }
+
+    func testProcessResponseWithPhoneStatusSetsStateToPhone() async {
+        let phoneResponse = ChargeCardTransaction(status: .sendPhone)
+        await serviceUnderTest.processTransactionResponse(phoneResponse)
+        XCTAssertEqual(serviceUnderTest.chargeCardState, .phoneNumber)
+    }
+
+    func testProcessResponseWithOTPStatusSetsStateToOTP() async {
+        let expectedPhoneNumber = "0123456789"
+        let otpResponse = ChargeCardTransaction(status: .sendOtp, customerPhone: expectedPhoneNumber)
+        await serviceUnderTest.processTransactionResponse(otpResponse)
+        XCTAssertEqual(serviceUnderTest.chargeCardState, .otp(phoneNumber: expectedPhoneNumber))
+    }
+
+    func testProcessResponseWithPinStatusSetsStateToPin() async {
+        let pinResponse = ChargeCardTransaction(status: .sendPin)
+        await serviceUnderTest.processTransactionResponse(pinResponse)
+        XCTAssertEqual(serviceUnderTest.chargeCardState, .pin)
+    }
+
+    func testProcessResponseWithSuccessStatusCallsChargeContainerToUpdateStatus() async {
+        let successResponse = ChargeCardTransaction(status: .success)
+        await serviceUnderTest.processTransactionResponse(successResponse)
+        XCTAssertTrue(mockChargeContainer.transactionSuccessful)
+    }
+
+    func testProcessResponseWithFailureStatusCallsChargeContainerToUpdateStatus() async {
+        let successResponse = ChargeCardTransaction(status: .failed)
+        await serviceUnderTest.processTransactionResponse(successResponse)
+        XCTAssertTrue(mockChargeContainer.transactionFailed)
+    }
 }
 
 extension ChargeCardState: Equatable {


### PR DESCRIPTION
# Notes:
As part of the attempt at connecting parts together, we are now changing the `ChargeCardState` based on the responses that we get.
Added a few unit tests for these simple scenarios