### PR TITLE
Integrating actual endpoints to charge card repo

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
@@ -1,25 +1,40 @@
 import PaystackCore
 
-// TODO: Make actual calls here once we finalize API mocking
 struct ChargeCardRepositoryImplementation: ChargeCardRepository {
 
+    let paystack: Paystack
+
+    init() {
+        self.paystack = PaystackContainer.instance.retrieve()
+    }
+
     func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction {
-        ChargeCardTransaction.example
+        let response = try await paystack.authenticateCharge(withBirthday: birthday,
+                                                             accessCode: accessCode).async()
+        return ChargeCardTransaction.from(response)
     }
 
     func submitPhone(_ phone: String, accessCode: String) async throws -> ChargeCardTransaction {
-        ChargeCardTransaction.example
+        let response = try await paystack.authenticateCharge(withPhone: phone,
+                                                             accessCode: accessCode).async()
+        return ChargeCardTransaction.from(response)
     }
 
     func submitOTP(_ otp: String, accessCode: String) async throws -> ChargeCardTransaction {
-        ChargeCardTransaction.example
+        let response = try await paystack.authenticateCharge(withOtp: otp,
+                                                             accessCode: accessCode).async()
+        return ChargeCardTransaction.from(response)
     }
 
     func submitAddress(_ address: Address, accessCode: String) async throws -> ChargeCardTransaction {
-        ChargeCardTransaction.example
+        let response = try await paystack.authenticateCharge(withAddress: address,
+                                                             accessCode: accessCode).async()
+        return ChargeCardTransaction.from(response)
     }
 
     func submitPin(_ pin: String, accessCode: String) async throws -> ChargeCardTransaction {
-        ChargeCardTransaction.example
+        let response = try await paystack.authenticateCharge(withPin: pin,
+                                                             accessCode: accessCode).async()
+        return ChargeCardTransaction.from(response)
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardRepository/ChargeCardRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardRepository/ChargeCardRepositoryImplementationTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import PaystackCore
+@testable import PaystackUI
+
+final class ChargeCardRepositoryImplementationTests: PSTestCase {
+
+    let apiKey = "testsk_Example"
+    var serviceUnderTest: ChargeCardRepositoryImplementation!
+    var paystack: Paystack!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        paystack = try PaystackBuilder.newInstance.setKey(apiKey).build()
+        PaystackContainer.instance.store(paystack)
+        serviceUnderTest = ChargeCardRepositoryImplementation()
+    }
+
+    func testSubmitBirthdaySubmitsRequestUsingPaystackObjectAndMapsCorrectlyToModel() async throws {
+        let birthdayRequestBody = SubmitBirthdayRequest(birthday: "1990-01-01",
+                                                        accessCode: "test_access")
+
+        mockServiceExecutor
+            .expectURL("https://api.paystack.co/charge/submit_birthday")
+            .expectMethod(.post)
+            .expectHeader("Authorization", "Bearer \(apiKey)")
+            .expectBody(birthdayRequestBody)
+            .andReturn(json: "ChargeAuthenticationResponse")
+
+        let result = try await serviceUnderTest.submitBirthday("1990-01-01",
+                                                               accessCode: "test_access")
+        XCTAssertEqual(result, .jsonExample)
+    }
+
+    func testSubmitPhoneSubmitsRequestUsingPaystackObjectAndMapsCorrectlyToModel() async throws {
+        let phoneRequestBody = SubmitPhoneRequest(phone: "0111234567", accessCode: "test_access")
+
+        mockServiceExecutor
+            .expectURL("https://api.paystack.co/charge/submit_phone")
+            .expectMethod(.post)
+            .expectHeader("Authorization", "Bearer \(apiKey)")
+            .expectBody(phoneRequestBody)
+            .andReturn(json: "ChargeAuthenticationResponse")
+
+        let result = try await serviceUnderTest.submitPhone("0111234567",
+                                                            accessCode: "test_access")
+        XCTAssertEqual(result, .jsonExample)
+    }
+
+    func testSubmitOTPSubmitsRequestUsingPaystackObjectAndMapsCorrectlyToModel() async throws {
+        let otpRequestBody = SubmitOtpRequest(otp: "12345", accessCode: "test_access")
+
+        mockServiceExecutor
+            .expectURL("https://api.paystack.co/charge/submit_otp")
+            .expectMethod(.post)
+            .expectHeader("Authorization", "Bearer \(apiKey)")
+            .expectBody(otpRequestBody)
+            .andReturn(json: "ChargeAuthenticationResponse")
+
+        let result = try await serviceUnderTest.submitOTP("12345", accessCode: "test_access")
+        XCTAssertEqual(result, .jsonExample)
+    }
+
+    func testSubmitPinSubmitsRequestUsingPaystackObjectAndMapsCorrectlyToModel() async throws {
+        let pinRequestBody = SubmitPinRequest(pin: "123456", accessCode: "test_access")
+
+        mockServiceExecutor
+            .expectURL("https://api.paystack.co/charge/submit_pin")
+            .expectMethod(.post)
+            .expectHeader("Authorization", "Bearer \(apiKey)")
+            .expectBody(pinRequestBody)
+            .andReturn(json: "ChargeAuthenticationResponse")
+
+        let result = try await serviceUnderTest.submitPin("123456", accessCode: "test_access")
+        XCTAssertEqual(result, .jsonExample)
+    }
+
+    func testSubmitAddressSubmitsRequestUsingPaystackObjectAndMapsCorrectlyToModel() async throws {
+        let address = Address(address: "123 Road", city: "Johannesburg",
+                              state: "Gauteng", zipCode: "1234")
+        let addressRequestBody = SubmitAddressRequest(address: address,
+                                                      accessCode: "test_access")
+
+        mockServiceExecutor
+            .expectURL("https://api.paystack.co/charge/submit_address")
+            .expectMethod(.post)
+            .expectHeader("Authorization", "Bearer \(apiKey)")
+            .expectBody(addressRequestBody)
+            .andReturn(json: "ChargeAuthenticationResponse")
+
+        let result = try await serviceUnderTest.submitAddress(address, accessCode: "test_access")
+        XCTAssertEqual(result, .jsonExample)
+    }
+
+}
+
+// MARK: - ChargeCardTransaction Based off Json result
+private extension ChargeCardTransaction {
+    static var jsonExample: ChargeCardTransaction {
+        ChargeCardTransaction(status: .success,
+                              customerPhone: "+27123456789",
+                              countryCode: "NG")
+    }
+}


### PR DESCRIPTION
# Notes:
Pretty simple and small one here. Previously the `ChargeCardRepositoryImplementation` was just returning the same object. Changing this to return actual results from the paystack object now.
Added unit tests as well