### PR TITLE
Removed OTP Resend functionality

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPVIew.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPVIew.swift
@@ -7,8 +7,6 @@ struct CardOTPVIew: View {
     @StateObject
     var viewModel: CardOTPViewModel
 
-    private let timer = Timer.publish(every: 1, on: .main, in: .common)
-
     init(phoneNumber: String,
          chargeCardContainer: ChargeCardContainer) {
         self._viewModel = StateObject(wrappedValue: CardOTPViewModel(
@@ -29,48 +27,12 @@ struct CardOTPVIew: View {
                 FormInput(title: "Authorize",
                           enabled: viewModel.isValid,
                           action: viewModel.submitOTP,
-                          secondaryAction: viewModel.cancelTransaction,
-                          supplementaryContent: resendOTPSection) {
+                          secondaryAction: viewModel.cancelTransaction) {
                     otpField
                 }
             }
             .padding(.doublePadding)
         }
-    }
-
-    @ViewBuilder
-    var resendOTPSection: some View {
-        if viewModel.otpResendAttempts < 2 {
-            if viewModel.secondsBeforeResendOTP > 0 {
-                (Text("Resend OTP in ").foregroundColor(.gray01) +
-                 Text(viewModel.secondsBeforeResendOTP.formatSecondsAsMinutesAndSeconds())
-                    .foregroundColor(.stackGreen))
-                .font(.body14M)
-            } else {
-                Button("Resend OTP", action: resendOTP)
-                    .font(.body14M)
-                    .foregroundColor(.stackGreen)
-            }
-        } else {
-            otpResendAttemptLimitView
-        }
-    }
-
-    var otpResendAttemptLimitView: some View {
-        Text("We are having trouble sending the OTP. Kindly wait a " +
-             "few more minutes or cancel the transaction.")
-        .multilineTextAlignment(.center)
-        .foregroundColor(.navy03)
-        .font(.body14R)
-        .fixedSize(horizontal: false, vertical: true)
-    }
-
-    private func resendOTP() {
-        viewModel.resendOTP()
-        viewModel.subscription = timer.autoconnect()
-            .sink { _ in
-                viewModel.decreaseOTPCountdownTime()
-            }
     }
 
     @ViewBuilder

--- a/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPViewModel.swift
@@ -10,13 +10,6 @@ class CardOTPViewModel: ObservableObject {
     @Published
     var otp: String = ""
 
-    @Published
-    var secondsBeforeResendOTP = 0
-    var otpResendLength = 60
-
-    var subscription: AnyCancellable?
-    var otpResendAttempts = 0
-
     init(phoneNumber: String,
          chargeCardContainer: ChargeCardContainer,
          repository: ChargeCardRepository = ChargeCardRepositoryImplementation()) {
@@ -41,19 +34,5 @@ class CardOTPViewModel: ObservableObject {
 
     func cancelTransaction() {
         chargeCardContainer.restartCardPayment()
-    }
-
-    func resendOTP() {
-        otpResendAttempts += 1
-        secondsBeforeResendOTP = otpResendLength
-        // TODO: Perform API call
-    }
-
-    func decreaseOTPCountdownTime() {
-        if secondsBeforeResendOTP > 0 {
-            secondsBeforeResendOTP -= 1
-        } else {
-            subscription?.cancel()
-        }
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardOTP/CardOTPViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardOTP/CardOTPViewModelTests.swift
@@ -35,26 +35,6 @@ final class CardOTPViewModelTests: XCTestCase {
         XCTAssertTrue(mockChargeCardContainer.cardPaymentRestarted)
     }
 
-    func testResendOTPIncreasesResendCountAndResetsTimeToResendLength() {
-        let expectedResendLength = 5
-        serviceUnderTest.otpResendLength = expectedResendLength
-        serviceUnderTest.resendOTP()
-        XCTAssertEqual(serviceUnderTest.secondsBeforeResendOTP, expectedResendLength)
-        XCTAssertEqual(serviceUnderTest.otpResendAttempts, 1)
-    }
-
-    func testDecreaseOTPTimerDecrementsRemainingTimeByOne() {
-        serviceUnderTest.secondsBeforeResendOTP = 10
-        serviceUnderTest.decreaseOTPCountdownTime()
-        XCTAssertEqual(serviceUnderTest.secondsBeforeResendOTP, 9)
-    }
-
-    func testDecreaseOTPTimerDoesNotDecrementWhenRemainingTimeIsZero() {
-        serviceUnderTest.secondsBeforeResendOTP = 0
-        serviceUnderTest.decreaseOTPCountdownTime()
-        XCTAssertEqual(serviceUnderTest.secondsBeforeResendOTP, 0)
-    }
-
     func testSubmittingOTPSendsRepositoryResultToCardContainer() async throws {
         let expectedOTP = "123456"
         mockRepository.expectedChargeCardTransaction = .example


### PR DESCRIPTION
# Notes:
After discovering that we don't have an actual endpoint for this, we've decided to remove this functionality.
Simply removing everything related to resend OTP

# Visuals:
![Screenshot 2023-08-28 at 23 59 06](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/456466c8-87bf-4e4b-9abc-3fdedd99fdb2)
