### PR TITLE
Added integration for submitting card details

### DIFF
--- a/Sources/PaystackSDK/Core/Models/Models/Charge/CardCharge.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Charge/CardCharge.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct CardCharge: Codable {
+public struct CardCharge: Codable, Equatable {
     var number: String
     var cvv: String
     var expiryMonth: String

--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsView.swift
@@ -19,10 +19,12 @@ struct CardDetailsView: View {
     private var showExpiryError = false
 
     init(amountDetails: AmountCurrency,
+         encryptionKey: String,
          chargeCardContainer: ChargeCardContainer) {
         self._viewModel = StateObject(
             wrappedValue: CardDetailsViewModel(
                 amountDetails: amountDetails,
+                encryptionKey: encryptionKey,
                 chargeCardContainer: chargeCardContainer))
     }
 
@@ -100,6 +102,7 @@ struct CardDetailsView_Previews: PreviewProvider {
         CardDetailsView(
             amountDetails: .init(amount: 10000,
                                  currency: "USD"),
+            encryptionKey: "test_encryption_key",
             chargeCardContainer: ChargeCardViewModel(
                 transactionDetails: .example,
                 chargeContainer: ChargeViewModel(accessCode: "access_code")))

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -14,12 +14,14 @@ struct ChargeCardView: View {
 
     var body: some View {
         switch viewModel.chargeCardState {
-        case .cardDetails(let amount):
+        case .cardDetails(let amount, let encryptionKey):
             CardDetailsView(amountDetails: amount,
+                            encryptionKey: encryptionKey,
                             chargeCardContainer: viewModel)
 
-        case .testModeCardSelection(let amount):
+        case .testModeCardSelection(let amount, let encryptionKey):
             TestModeCardSelectionView(amountDetails: amount,
+                                      encryptionKey: encryptionKey,
                                       chargeCardContainer: viewModel)
 
         case .pin:

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -13,9 +13,10 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
         self.transactionDetails = transactionDetails
         self.chargeContainer = chargeContainer
         let amountDetails = transactionDetails.amountCurrency
+        let encryptionKey = transactionDetails.publicEncryptionKey
         self.chargeCardState = transactionDetails.domain == .live ?
-            .cardDetails(amount: amountDetails) :
-            .testModeCardSelection(amount: amountDetails)
+            .cardDetails(amount: amountDetails, encryptionKey: encryptionKey) :
+            .testModeCardSelection(amount: amountDetails, encryptionKey: encryptionKey)
     }
 
     var accessCode: String {
@@ -27,11 +28,13 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
     }
 
     func restartCardPayment() {
-        chargeCardState = .cardDetails(amount: transactionDetails.amountCurrency)
+        chargeCardState = .cardDetails(amount: transactionDetails.amountCurrency,
+                                       encryptionKey: transactionDetails.publicEncryptionKey)
     }
 
     func switchToTestModeCardSelection() {
-        chargeCardState = .testModeCardSelection(amount: transactionDetails.amountCurrency)
+        chargeCardState = .testModeCardSelection(amount: transactionDetails.amountCurrency,
+                                                 encryptionKey: transactionDetails.publicEncryptionKey)
     }
 
     @MainActor

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 enum ChargeCardState {
-    case cardDetails(amount: AmountCurrency)
-    case testModeCardSelection(amount: AmountCurrency)
+    case cardDetails(amount: AmountCurrency, encryptionKey: String)
+    case testModeCardSelection(amount: AmountCurrency, encryptionKey: String)
     case pin
     case phoneNumber
     case otp(phoneNumber: String)

--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepository.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepository.swift
@@ -1,6 +1,8 @@
 import PaystackCore
 
 protocol ChargeCardRepository {
+    func submitCardDetails(_ card: CardCharge, publicEncryptionKey: String,
+                           accessCode: String) async throws -> ChargeCardTransaction
     func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction
     func submitPhone(_ phone: String, accessCode: String) async throws -> ChargeCardTransaction
     func submitOTP(_ otp: String, accessCode: String) async throws -> ChargeCardTransaction

--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
@@ -8,6 +8,14 @@ struct ChargeCardRepositoryImplementation: ChargeCardRepository {
         self.paystack = PaystackContainer.instance.retrieve()
     }
 
+    func submitCardDetails(_ card: CardCharge, publicEncryptionKey: String,
+                           accessCode: String) async throws -> ChargeCardTransaction {
+        let response = try await paystack.chargeCard(card,
+                                                     publicEncryptionKey: publicEncryptionKey,
+                                                     accessCode: accessCode).async()
+        return ChargeCardTransaction.from(response)
+    }
+
     func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction {
         let response = try await paystack.authenticateCharge(withBirthday: birthday,
                                                              accessCode: accessCode).async()

--- a/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestCards.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestCards.swift
@@ -42,14 +42,25 @@ extension TestCard {
         }
     }
 
-    var expiry: String {
+    var expiryMonth: String {
         switch self {
         case .success:
-            return "08/24"
+            return "08"
         case .bankAuthentication:
-            return "08/24"
+            return "08"
         case .declined:
-            return "08/24"
+            return "08"
+        }
+    }
+
+    var expiryYear: String {
+        switch self {
+        case .success:
+            return "24"
+        case .bankAuthentication:
+            return "24"
+        case .declined:
+            return "24"
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionView.swift
@@ -7,10 +7,12 @@ struct TestModeCardSelectionView: View {
     var viewModel: TestModeCardSelectionViewModel
 
     init(amountDetails: AmountCurrency,
+         encryptionKey: String,
          chargeCardContainer: ChargeCardContainer) {
         self._viewModel = StateObject(
             wrappedValue: TestModeCardSelectionViewModel(
                 amountDetails: amountDetails,
+                encryptionKey: encryptionKey,
                 chargeCardContainer: chargeCardContainer))
     }
 
@@ -59,6 +61,7 @@ struct TestModeCardSelectionView_Previews: PreviewProvider {
         TestModeCardSelectionView(
             amountDetails: .init(amount: 10000,
                                  currency: "USD"),
+            encryptionKey: "test_encryption_key",
             chargeCardContainer: ChargeCardViewModel(
                 transactionDetails: .example,
                 chargeContainer: ChargeViewModel(accessCode: "access_code")))

--- a/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionViewModel.swift
@@ -1,17 +1,24 @@
 import Foundation
+import PaystackCore
 
 class TestModeCardSelectionViewModel: ObservableObject {
 
     var amountDetails: AmountCurrency
+    var encryptionKey: String
     var chargeCardContainer: ChargeCardContainer
+    var repository: ChargeCardRepository
 
     @Published
     var testCard: TestCard?
 
     init(amountDetails: AmountCurrency,
-         chargeCardContainer: ChargeCardContainer) {
+         encryptionKey: String,
+         chargeCardContainer: ChargeCardContainer,
+         repository: ChargeCardRepository = ChargeCardRepositoryImplementation()) {
         self.amountDetails = amountDetails
+        self.encryptionKey = encryptionKey
         self.chargeCardContainer = chargeCardContainer
+        self.repository = repository
     }
 
     var buttonTitle: String {
@@ -23,7 +30,20 @@ class TestModeCardSelectionViewModel: ObservableObject {
     }
 
     func proceedWithTestCard() async {
-        // TODO: Perform API call with card details
+        do {
+            guard let testCard else { return }
+            let card = CardCharge(number: testCard.cardNumber,
+                                  cvv: testCard.cvv,
+                                  expiryMonth: testCard.expiryMonth,
+                                  expiryYear: testCard.expiryYear)
+
+            let authenticationResult = try await repository.submitCardDetails(
+                card, publicEncryptionKey: encryptionKey, accessCode: chargeCardContainer.accessCode)
+            chargeCardContainer.processTransactionResponse(authenticationResult)
+        } catch {
+            print(error)
+            // TODO: Determine error handling once we have further information
+        }
     }
 
     func displayManualCardDetailsEntry() {

--- a/Sources/PaystackUI/Components/Form/FormInputViewModel.swift
+++ b/Sources/PaystackUI/Components/Form/FormInputViewModel.swift
@@ -11,6 +11,7 @@ class FormInputViewModel: ObservableObject {
         self.action = action
     }
 
+    @MainActor
     func submit() async {
         showLoading = true
         await action()

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -18,7 +18,8 @@ final class ChargeCardViewModelTests: PSTestCase {
         serviceUnderTest.chargeCardState = .pin
         serviceUnderTest.restartCardPayment()
         XCTAssertEqual(serviceUnderTest.chargeCardState,
-                       .cardDetails(amount: mockTransactionDetails.amountCurrency))
+                       .cardDetails(amount: mockTransactionDetails.amountCurrency,
+                                    encryptionKey: mockTransactionDetails.publicEncryptionKey))
     }
 
     func testInitialStateIsSetToCardDetailsInLiveMode() {
@@ -31,7 +32,8 @@ final class ChargeCardViewModelTests: PSTestCase {
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
                                                chargeContainer: mockChargeContainer)
         XCTAssertEqual(serviceUnderTest.chargeCardState,
-            .cardDetails(amount: transactionDetails.amountCurrency))
+                       .cardDetails(amount: transactionDetails.amountCurrency,
+                                    encryptionKey: transactionDetails.publicEncryptionKey))
     }
 
     func testInitialStateIsSetToTestModeCardSelectionInTestMode() {
@@ -44,7 +46,8 @@ final class ChargeCardViewModelTests: PSTestCase {
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
                                                chargeContainer: mockChargeContainer)
         XCTAssertEqual(serviceUnderTest.chargeCardState,
-                       .testModeCardSelection(amount: transactionDetails.amountCurrency))
+                       .testModeCardSelection(amount: transactionDetails.amountCurrency,
+                                              encryptionKey: transactionDetails.publicEncryptionKey))
     }
 
     func testInTestModeReturnsTrueIfDomainIsTest() {
@@ -80,7 +83,8 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          publicEncryptionKey: "test_encryption_key")
         serviceUnderTest.switchToTestModeCardSelection()
         XCTAssertEqual(serviceUnderTest.chargeCardState,
-                       .testModeCardSelection(amount: transactionDetails.amountCurrency))
+                       .testModeCardSelection(amount: transactionDetails.amountCurrency,
+                                              encryptionKey: transactionDetails.publicEncryptionKey))
     }
 
     func testProcessResponseWithAddressStatusSetsStateToAddress() async {

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardRepository.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardRepository.swift
@@ -7,11 +7,18 @@ class MockChargeCardRepository: ChargeCardRepository {
     var expectedChargeCardTransaction: ChargeCardTransaction?
     var expectedErrorResponse: Error?
 
+    var cardDetailsSubmitted: (card: CardCharge?, accessCode: String,
+                               publicEncryptionKey: String) = (nil, "", "")
     var birthdaySubmitted: (birthday: String, accessCode: String) = ("", "")
     var phoneSubmitted: (phone: String, accessCode: String) = ("", "")
     var otpSubmitted: (otp: String, accessCode: String) = ("", "")
     var addressSubmitted: (address: Address?, accessCode: String) = (nil, "")
     var pinSubmitted: (pin: String, accessCode: String) = ("", "")
+
+    func submitCardDetails(_ card: CardCharge, publicEncryptionKey: String, accessCode: String) async throws -> ChargeCardTransaction {
+        cardDetailsSubmitted = (card, accessCode, publicEncryptionKey)
+        return try await mockedResponse()
+    }
 
     func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction {
         birthdaySubmitted = (birthday, accessCode)

--- a/Tests/PaystackSDKTests/UI/Charge/TestMode/TestModeCardSelectionViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/TestMode/TestModeCardSelectionViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import PaystackCore
 @testable import PaystackUI
 
 final class TestModeCardSelectionViewModelTests: XCTestCase {
@@ -6,12 +7,17 @@ final class TestModeCardSelectionViewModelTests: XCTestCase {
     var serviceUnderTest: TestModeCardSelectionViewModel!
     var mockAmountCurrency = AmountCurrency(amount: 10000, currency: "USD")
     var mockChargeCardContainer: MockChargeCardContainer!
+    var mockEncryptionKey = "MOCK_ENCRYPTION_KEY"
+    var mockRepository: MockChargeCardRepository!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         mockChargeCardContainer = MockChargeCardContainer()
+        mockRepository = MockChargeCardRepository()
         serviceUnderTest = TestModeCardSelectionViewModel(amountDetails: mockAmountCurrency,
-                                                          chargeCardContainer: mockChargeCardContainer)
+                                                          encryptionKey: mockEncryptionKey,
+                                                          chargeCardContainer: mockChargeCardContainer,
+                                                          repository: mockRepository)
     }
 
     func testFormIsValidIfTestCardIsSelected() {
@@ -27,5 +33,20 @@ final class TestModeCardSelectionViewModelTests: XCTestCase {
     func testUseManualCardEntryCallsContainerToSwitchToCardDetailsFlow() {
         serviceUnderTest.displayManualCardDetailsEntry()
         XCTAssertTrue(mockChargeCardContainer.cardPaymentRestarted)
+    }
+
+    func testSubmittingTestardDetailsBuildsCardModelAndForwardsRepositoryResponseToContainer() async throws {
+        serviceUnderTest.testCard = .success
+
+        mockRepository.expectedChargeCardTransaction = .example
+        await serviceUnderTest.proceedWithTestCard()
+
+        let expectedCard = CardCharge(number: TestCard.success.cardNumber,
+                                      cvv: TestCard.success.cvv,
+                                      expiryMonth: TestCard.success.expiryMonth,
+                                      expiryYear: TestCard.success.expiryYear)
+
+        XCTAssertEqual(mockRepository.cardDetailsSubmitted.card, expectedCard)
+        XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
     }
 }


### PR DESCRIPTION
# Changes
- Added encryptionKey as part of the initializer for CardDetails and TestCardSelection view and view model, a lot of files affected for this change
- Created a seperate function to get expiry components from the expiry date string
- Submitted card details in `CardDetailsViewModel`
- Added a function to `ChargeCardRepository` and its implementation for submitting card details using the Paystack Core SDK
- Modified `TestCard` to simpliy expiry date fields
- Added logic to `TestModeCardSelectionViewModel` to submit the selected test card
- Added and updated unit tests