### PR TITLE
Handled failure scenario

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -42,12 +42,19 @@ struct ChargeCardView: View {
             CardBirthdayView(chargeCardContainer: viewModel)
 
         case .error(let error):
-            ErrorView(message: error.message,
-                      buttonText: viewModel.inTestMode ?
-                      "Retry with test details" : "Try another card",
-                      buttonAction: viewModel.inTestMode ?
-                      viewModel.switchToTestModeCardSelection : viewModel.restartCardPayment)
+            errorView(message: error.message)
+
+        case .failed:
+            errorView(message: "Declined")
         }
+    }
+
+    func errorView(message: String) -> some View {
+        ErrorView(message: message,
+                  buttonText: viewModel.inTestMode ?
+                  "Retry with test details" : "Try another card",
+                  buttonAction: viewModel.inTestMode ?
+                  viewModel.switchToTestModeCardSelection : viewModel.restartCardPayment)
     }
 
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -60,7 +60,7 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
         case .success:
             chargeContainer.processSuccessfulTransaction(details: transactionDetails)
         case .failed:
-            chargeContainer.processFailedTransaction()
+            chargeCardState = .failed
         case .pending:
             // TODO: Add logic for pending state
             break

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
@@ -9,4 +9,5 @@ enum ChargeCardState {
     case address(states: [String])
     case birthday
     case error(ChargeCardError)
+    case failed
 }

--- a/Sources/PaystackUI/Charge/ChargeContainer.swift
+++ b/Sources/PaystackUI/Charge/ChargeContainer.swift
@@ -2,5 +2,4 @@ import Foundation
 
 protocol ChargeContainer {
     func processSuccessfulTransaction(details: VerifyAccessCode)
-    func processFailedTransaction()
 }

--- a/Sources/PaystackUI/Charge/ChargeView.swift
+++ b/Sources/PaystackUI/Charge/ChargeView.swift
@@ -59,7 +59,7 @@ struct ChargeView: View {
     func chargeCancelled() {
         switch viewModel.transactionState {
         case .success:
-            visibilityContainer.completeAndDismiss(with: .success)
+            visibilityContainer.completeAndDismiss(with: .completed)
         default:
             visibilityContainer.cancelAndDismiss()
         }

--- a/Sources/PaystackUI/Charge/ChargeViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeViewModel.swift
@@ -38,10 +38,6 @@ extension ChargeViewModel: ChargeContainer {
         transactionState = .success(amount: details.amountCurrency, merchant: details.merchantName)
     }
 
-    func processFailedTransaction() {
-        // TODO: Will handle in another PR
-    }
-
 }
 
 // MARK: UI State Management

--- a/Sources/PaystackUI/Charge/Success/ChargeSuccessView.swift
+++ b/Sources/PaystackUI/Charge/Success/ChargeSuccessView.swift
@@ -26,7 +26,7 @@ struct ChargeSuccessView: View {
 
     func dismissAutomatically() async {
         try? await Task.sleep(nanoseconds: 1_500_000_000)
-        visibilityContainer.completeAndDismiss(with: .success)
+        visibilityContainer.completeAndDismiss(with: .completed)
     }
 }
 

--- a/Sources/PaystackUI/Models/TransactionResult.swift
+++ b/Sources/PaystackUI/Models/TransactionResult.swift
@@ -1,9 +1,19 @@
 import Foundation
 
-// TODO: This will be built upon to include more information/more statuses if relevant
+/// The result of a payment attempt
 public enum TransactionResult {
-    case success
-    case failure
-    case pending
+
+    /** The customer's payment process is complete.
+
+    Your server should verify the transaction status and amount before providing value.
+    A transaction can be confirmed by using either webhooks or the verify transactions endpoint.
+    See [Paystack's docs](https://paystack.com/docs/payments/verify-payments/) */
+    case completed
+
+    /// The customer canceled the payment attempt.
     case cancelled
+
+    // TODO: Pass a custom error type here later and provide a better description
+    /// An unexpected error occurred whilst attempting payment.
+    case error(Error)
 }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -131,10 +131,10 @@ final class ChargeCardViewModelTests: PSTestCase {
         XCTAssertTrue(mockChargeContainer.transactionSuccessful)
     }
 
-    func testProcessResponseWithFailureStatusCallsChargeContainerToUpdateStatus() async {
+    func testProcessResponseWithFailureSetsStateToFailed() async {
         let successResponse = ChargeCardTransaction(status: .failed)
         await serviceUnderTest.processTransactionResponse(successResponse)
-        XCTAssertTrue(mockChargeContainer.transactionFailed)
+        XCTAssertEqual(serviceUnderTest.chargeCardState, .failed)
     }
 }
 
@@ -157,6 +157,8 @@ extension ChargeCardState: Equatable {
             return true
         case (.error(let first), .error(let second)):
             return first == second
+        case (.failed, .failed):
+            return true
         default:
             return false
         }

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeContainer.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeContainer.swift
@@ -3,14 +3,9 @@ import Foundation
 
 class MockChargeContainer: ChargeContainer {
     var transactionSuccessful = false
-    var transactionFailed = false
 
     func processSuccessfulTransaction(details: VerifyAccessCode) {
         transactionSuccessful = true
-    }
-
-    func processFailedTransaction() {
-        transactionFailed = true
     }
 
 }


### PR DESCRIPTION
# Discussion:
You will notice that the concept of returning an error has been removed. After a discussion with Michael, we have come to the conclusion that the SDK does not actually allow you to end on a failure, you either need to finish a transaction, cancel it, or keep retrying until you perform one of the prior scenarios.

Changed the states to reflect this.

# Changes:
- Created a common `ErrorView` in `ChargeCardView ` to avoid duplication 
- Added a `failed` state to `ChargeCardState` 
- Modified `ChargeCardViewModel` to set the failed state directly instead of calling the parent
- Removed `processFailedTransaction` as that is no longer a valid scenario
- Renamed states in `TransactionResult` and provided documentation for it


# Visuals:
![Screenshot 2023-09-04 at 16 48 02](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/da2ca3bb-51bd-418f-877a-36697aa5af9e)