### PR TITLE
Added Check pending charge endpoint to core SDK

### DIFF
--- a/Sources/PaystackSDK/API/Transactions/TransactionService.swift
+++ b/Sources/PaystackSDK/API/Transactions/TransactionService.swift
@@ -2,6 +2,7 @@ import Foundation
 
 protocol TransactionService: PaystackService {
     func getVerifyAccessCode(_ code: String) -> Service<VerifyAccessCodeResponse>
+    func getCheckPendingCharge(for accessCode: String) -> Service<ChargeResponse>
     func postSubmitCardCharge(_ request: ChargeCardRequest) -> Service<ChargeResponse>
 }
 
@@ -15,6 +16,11 @@ struct TransactionServiceImplementation: TransactionService {
 
     func postSubmitCardCharge(_ request: ChargeCardRequest) -> Service<ChargeResponse> {
         return post("/charge", request)
+            .asService()
+    }
+
+    func getCheckPendingCharge(for accessCode: String) -> Service<ChargeResponse> {
+        return get("/charge/\(accessCode)")
             .asService()
     }
 

--- a/Sources/PaystackSDK/API/Transactions/Transactions.swift
+++ b/Sources/PaystackSDK/API/Transactions/Transactions.swift
@@ -22,6 +22,15 @@ public extension Paystack {
         return service.postSubmitCardCharge(request)
     }
 
+    // TODO: Update this description with the correct statues to use this
+    /// Checks the status of a charge that has already been initiated.
+    /// This should be used when a transaction returns the `timeout` status
+    /// - Parameter code: The access code of the transaction being queried
+    /// - Returns: A ``Service`` with the latest ``VerifyAccessCodeResponse`` response
+    func checkPendingCharge(forAccessCode code: String) -> Service<ChargeResponse> {
+        return service.getCheckPendingCharge(for: code)
+    }
+
     /// Verifies an access code for a transaction and returns information related to the transaction, including the supported payment channels
     /// - Parameter code: The access code for the current transaction
     /// - Returns: A ``Service`` with the ``VerifyAccessCodeResponse`` response

--- a/Sources/PaystackSDK/Core/Models/Models/Charge/Authorization.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Charge/Authorization.swift
@@ -5,5 +5,5 @@ public struct Authorization: Codable {
     public var expYear, channel, cardType, bank: String
     public var countryCode, brand: String
     public var reusable: Bool
-    public var signature, accountName: String
+    public var signature, accountName: String?
 }

--- a/Sources/PaystackSDK/Core/Models/Models/Charge/ChargeResponseData.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Charge/ChargeResponseData.swift
@@ -8,6 +8,9 @@ public struct ChargeResponseData: Codable {
     public var reference: String
     public var domain: Domain
     public var redirectUrl: String?
+    public var url: String?
+    public var ussdCode: String?
+    public var qrCode: String?
     public var metadata: [String: String]?
     public var gatewayResponse: String?
     public var message: String?

--- a/Tests/PaystackSDKTests/API/Transactions/TransactionsTests.swift
+++ b/Tests/PaystackSDKTests/API/Transactions/TransactionsTests.swift
@@ -24,4 +24,14 @@ class TransactionsTests: PSTestCase {
         _ = try await serviceUnderTest.verifyAccessCode("access_code_test").async()
     }
 
+    func testChechPendingCharge() async throws {
+        mockServiceExecutor
+            .expectURL("https://api.paystack.co/transaction/charge/access_code_test")
+            .expectMethod(.get)
+            .expectHeader("Authorization", "Bearer \(apiKey)")
+            .andReturn(json: "ChargeAuthenticationResponse")
+
+        _ = try await serviceUnderTest.checkPendingCharge(forAccessCode: "access_code_test").async()
+    }
+
 }


### PR DESCRIPTION
# Changes:
- Added `getCheckPendingCharge` to `TransactionService` which performs a get request to the specified endpoint
- Added the publicly exposed instance of the above (`checkPendingCharge`) to the `Paystack` extension
- Additionally, modified the existing models based on contract changes
- Added unit tests to ensure the correct endpoint is hit