### PR TITLE
Using dynamic messages from BE for Phone and OTP

### DIFF
--- a/Sources/PaystackSDK/Core/Models/Models/Charge/ChargeResponseData.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Charge/ChargeResponseData.swift
@@ -11,6 +11,7 @@ public struct ChargeResponseData: Codable {
     public var url: String?
     public var ussdCode: String?
     public var qrCode: String?
+    public var displayText: String?
     public var metadata: [String: String]?
     public var gatewayResponse: String?
     public var message: String?

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -49,7 +49,7 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
         case .sendBirthday:
             chargeCardState = .birthday
         case .sendPhone:
-            chargeCardState = .phoneNumber
+            handleSendPhone(with: response)
         case .sendOtp:
             handleSendOtp(with: response)
         case .sendPin:
@@ -85,12 +85,15 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
         chargeCardState = .address(states: states)
     }
 
+    private func handleSendPhone(with response: ChargeCardTransaction) {
+        let displayText = response.displayText ??
+        "Please enter your mobile phone number (at least 10 digits)"
+        chargeCardState = .phoneNumber(displayMessage: displayText)
+    }
+
     private func handleSendOtp(with response: ChargeCardTransaction) {
-        guard let phoneNumber = response.customerPhone else {
-            Logger.error("No customer phone number found in ChargeCardTransaction response")
-            chargeCardState = .error(.generic)
-            return
-        }
-        chargeCardState = .otp(phoneNumber: phoneNumber)
+        let displayText = response.displayText ??
+        "Please enter the OTP sent to your mobile number"
+        chargeCardState = .otp(displayMessage: displayText)
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
@@ -4,8 +4,8 @@ enum ChargeCardState {
     case cardDetails(amount: AmountCurrency, encryptionKey: String)
     case testModeCardSelection(amount: AmountCurrency, encryptionKey: String)
     case pin
-    case phoneNumber
-    case otp(phoneNumber: String)
+    case phoneNumber(displayMessage: String)
+    case otp(displayMessage: String)
     case address(states: [String])
     case birthday
     case error(ChargeError)

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardTransaction.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardTransaction.swift
@@ -5,7 +5,7 @@ import PaystackCore
 struct ChargeCardTransaction: Equatable {
     var status: TransactionStatus
     var redirectUrl: String?
-    var customerPhone: String?
+    var displayText: String?
     var countryCode: String?
 }
 
@@ -14,7 +14,7 @@ extension ChargeCardTransaction {
     static func from(_ response: ChargeResponse) -> Self {
         ChargeCardTransaction(status: response.data.status,
                               redirectUrl: response.data.redirectUrl,
-                              customerPhone: response.data.customer?.phone,
+                              displayText: response.data.displayText,
                               countryCode: response.data.authorization?.countryCode)
     }
 

--- a/Tests/PaystackSDKTests/UI/Charge/CardRepository/ChargeCardRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardRepository/ChargeCardRepositoryImplementationTests.swift
@@ -97,7 +97,6 @@ final class ChargeCardRepositoryImplementationTests: PSTestCase {
 private extension ChargeCardTransaction {
     static var jsonExample: ChargeCardTransaction {
         ChargeCardTransaction(status: .success,
-                              customerPhone: "+27123456789",
                               countryCode: "NG")
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -128,22 +128,36 @@ final class ChargeCardViewModelTests: PSTestCase {
     }
 
     func testProcessResponseWithPhoneStatusSetsStateToPhone() async {
-        let phoneResponse = ChargeCardTransaction(status: .sendPhone)
+        let expectedDisplayText = "Test Display Text"
+        let phoneResponse = ChargeCardTransaction(status: .sendPhone,
+                                                  displayText: expectedDisplayText)
         await serviceUnderTest.processTransactionResponse(phoneResponse)
-        XCTAssertEqual(serviceUnderTest.chargeCardState, .phoneNumber)
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+            .phoneNumber(displayMessage: expectedDisplayText))
+    }
+
+    func testProcessResponseWithPhoneStatusDisplaysAGenericDisplayMessageWhenDisplayTextIsNull() async {
+        let genericExpectedOTPMessage = "Please enter your mobile phone number (at least 10 digits)"
+        let otpResponse = ChargeCardTransaction(status: .sendPhone)
+        await serviceUnderTest.processTransactionResponse(otpResponse)
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+            .phoneNumber(displayMessage: genericExpectedOTPMessage))
     }
 
     func testProcessResponseWithOTPStatusSetsStateToOTP() async {
-        let expectedPhoneNumber = "0123456789"
-        let otpResponse = ChargeCardTransaction(status: .sendOtp, customerPhone: expectedPhoneNumber)
+        let expectedDisplayText = "Test Display Text"
+        let otpResponse = ChargeCardTransaction(status: .sendOtp, displayText: expectedDisplayText)
         await serviceUnderTest.processTransactionResponse(otpResponse)
-        XCTAssertEqual(serviceUnderTest.chargeCardState, .otp(phoneNumber: expectedPhoneNumber))
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+            .otp(displayMessage: expectedDisplayText))
     }
 
-    func testProcessResponseWithOTPStatusSetsStatusToGenericErrorIfPhoneNumberIsNotPresent() async {
+    func testProcessResponseWithOTPStatusDisplaysAGenericDisplayMessageWhenDisplayTextIsNull() async {
+        let genericExpectedOTPMessage = "Please enter the OTP sent to your mobile number"
         let otpResponse = ChargeCardTransaction(status: .sendOtp)
         await serviceUnderTest.processTransactionResponse(otpResponse)
-        XCTAssertEqual(serviceUnderTest.chargeCardState, .error(.generic))
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+            .otp(displayMessage: genericExpectedOTPMessage))
     }
 
     func testProcessResponseWithPinStatusSetsStateToPin() async {


### PR DESCRIPTION
# Changes:
- Modified `ChargeResponseData` to add a `displayText` variable
- Added a `displayText` field to `ChargeCardTransaction` as well that gets mapped over
- Modified the logic in `ChargeCardViewModel` to look for a displayText for phone and otp
- Added and updated unit tests