### PR TITLE
Added error handling for each of the different state view models

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressViewModel.swift
@@ -41,7 +41,8 @@ class CardAddressViewModel: ObservableObject {
                 address, accessCode: chargeCardContainer.accessCode)
             await chargeCardContainer.processTransactionResponse(authenticationResult)
         } catch {
-            // TODO: Determine error handling once we have further information
+            let error = ChargeError(error: error)
+            chargeCardContainer.displayTransactionError(error)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
@@ -32,7 +32,8 @@ class CardBirthdayViewModel: ObservableObject {
                 formattedBirthday, accessCode: chargeCardContainer.accessCode)
             await chargeCardContainer.processTransactionResponse(authenticationResult)
         } catch {
-            // TODO: Determine error handling once we have further information
+            let error = ChargeError(error: error)
+            chargeCardContainer.displayTransactionError(error)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/CardDetails/CardDetailsViewModel.swift
@@ -77,7 +77,8 @@ class CardDetailsViewModel: ObservableObject {
                 card, publicEncryptionKey: encryptionKey, accessCode: chargeCardContainer.accessCode)
             await chargeCardContainer.processTransactionResponse(authenticationResult)
         } catch {
-            // TODO: Determine error handling once we have further information
+            let error = ChargeError(error: error)
+            chargeCardContainer.displayTransactionError(error)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPViewModel.swift
@@ -28,7 +28,8 @@ class CardOTPViewModel: ObservableObject {
                 otp, accessCode: chargeCardContainer.accessCode)
             await chargeCardContainer.processTransactionResponse(authenticationResult)
         } catch {
-            // TODO: Determine error handling once we have further information
+            let error = ChargeError(error: error)
+            chargeCardContainer.displayTransactionError(error)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneViewModel.swift
@@ -24,7 +24,8 @@ class CardPhoneViewModel: ObservableObject {
                 phoneNumber, accessCode: chargeCardContainer.accessCode)
             await chargeCardContainer.processTransactionResponse(authenticationResult)
         } catch {
-            // TODO: Determine error handling once we have further information
+            let error = ChargeError(error: error)
+            chargeCardContainer.displayTransactionError(error)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Pin/CardPinViewModel.swift
@@ -24,7 +24,8 @@ class CardPinViewModel: ObservableObject {
                 pinText, accessCode: chargeCardContainer.accessCode)
             await chargeCardContainer.processTransactionResponse(authenticationResult)
         } catch {
-            // TODO: Determine error handling once we have further information
+            let error = ChargeError(error: error)
+            chargeCardContainer.displayTransactionError(error)
         }
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/TestMode/TestModeCardSelectionViewModel.swift
@@ -41,8 +41,8 @@ class TestModeCardSelectionViewModel: ObservableObject {
                 card, publicEncryptionKey: encryptionKey, accessCode: chargeCardContainer.accessCode)
             await chargeCardContainer.processTransactionResponse(authenticationResult)
         } catch {
-            print(error)
-            // TODO: Determine error handling once we have further information
+            let error = ChargeError(error: error)
+            chargeCardContainer.displayTransactionError(error)
         }
     }
 

--- a/Tests/PaystackSDKTests/UI/Charge/CardAddress/CardAddressViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardAddress/CardAddressViewModelTests.swift
@@ -64,4 +64,19 @@ final class CardAddressViewModelTests: XCTestCase {
         XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
     }
 
+    func testSubmittingAddressWithErrorForwardsErrorToCardContainer() async {
+        let expectedErrorMessage = "Error Message"
+        let expectedError: PaystackError = .response(code: 400, message: expectedErrorMessage)
+        mockRepository.expectedErrorResponse = expectedError
+
+        serviceUnderTest.street = "123 Test Street"
+        serviceUnderTest.zipCode = "12345"
+        serviceUnderTest.city = "Test City"
+        serviceUnderTest.state = "Test State"
+        await serviceUnderTest.submitAddress()
+
+        XCTAssertEqual(mockChargeCardContainer.transactionError,
+            .paystackResponse(message: expectedErrorMessage))
+    }
+
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardBirthday/CardBirthdayViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardBirthday/CardBirthdayViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import PaystackCore
 @testable import PaystackUI
 
 final class CardBirthdayViewModelTests: XCTestCase {
@@ -52,5 +53,19 @@ final class CardBirthdayViewModelTests: XCTestCase {
         let expectedBirthdayFormat = "2000-01-01"
         XCTAssertEqual(mockRepository.birthdaySubmitted.birthday, expectedBirthdayFormat)
         XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
+    }
+
+    func testSubmittingBirthdayWithErrorForwardsErrorToCardContainer() async {
+        let expectedErrorMessage = "Error Message"
+        let expectedError: PaystackError = .response(code: 400, message: expectedErrorMessage)
+        mockRepository.expectedErrorResponse = expectedError
+
+        serviceUnderTest.year = "2000"
+        serviceUnderTest.month = .january
+        serviceUnderTest.day = "01"
+        await serviceUnderTest.submitBirthday()
+
+        XCTAssertEqual(mockChargeCardContainer.transactionError,
+            .paystackResponse(message: expectedErrorMessage))
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardDetails/CardDetailsViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardDetails/CardDetailsViewModelTests.swift
@@ -102,4 +102,18 @@ final class CardDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
     }
 
+    func testSubmittingCardDetailsWithErrorForwardsErrorToCardContainer() async {
+        let expectedErrorMessage = "Error Message"
+        let expectedError: PaystackError = .response(code: 400, message: expectedErrorMessage)
+        mockRepository.expectedErrorResponse = expectedError
+
+        serviceUnderTest.cardExpiry = "01 / 25"
+        serviceUnderTest.cardNumber = "1234 5678 9012 1234"
+        serviceUnderTest.cvv = "123"
+        await serviceUnderTest.submitCardDetails()
+
+        XCTAssertEqual(mockChargeCardContainer.transactionError,
+            .paystackResponse(message: expectedErrorMessage))
+    }
+
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardOTP/CardOTPViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardOTP/CardOTPViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import PaystackCore
 @testable import PaystackUI
 
 final class CardOTPViewModelTests: XCTestCase {
@@ -43,5 +44,17 @@ final class CardOTPViewModelTests: XCTestCase {
 
         XCTAssertEqual(mockRepository.otpSubmitted.otp, expectedOTP)
         XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
+    }
+
+    func testSubmittingOTPWithErrorForwardsErrorToCardContainer() async {
+        let expectedErrorMessage = "Error Message"
+        let expectedError: PaystackError = .response(code: 400, message: expectedErrorMessage)
+        mockRepository.expectedErrorResponse = expectedError
+
+        serviceUnderTest.otp = "123456"
+        await serviceUnderTest.submitOTP()
+
+        XCTAssertEqual(mockChargeCardContainer.transactionError,
+            .paystackResponse(message: expectedErrorMessage))
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardPhoneNumber/CardPhoneViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardPhoneNumber/CardPhoneViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import PaystackCore
 @testable import PaystackUI
 
 final class CardPhoneViewModelTests: XCTestCase {
@@ -41,5 +42,17 @@ final class CardPhoneViewModelTests: XCTestCase {
 
         XCTAssertEqual(mockRepository.phoneSubmitted.phone, expectedPhoneNumber)
         XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
+    }
+
+    func testSubmittingPhoneNumberWithErrorForwardsErrorToCardContainer() async {
+        let expectedErrorMessage = "Error Message"
+        let expectedError: PaystackError = .response(code: 400, message: expectedErrorMessage)
+        mockRepository.expectedErrorResponse = expectedError
+
+        serviceUnderTest.phoneNumber = "0123456789"
+        await serviceUnderTest.submitPhoneNumber()
+
+        XCTAssertEqual(mockChargeCardContainer.transactionError,
+            .paystackResponse(message: expectedErrorMessage))
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/CardPin/CardPinViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardPin/CardPinViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import PaystackCore
 @testable import PaystackUI
 
 final class CardPinViewModelTests: XCTestCase {
@@ -28,6 +29,18 @@ final class CardPinViewModelTests: XCTestCase {
 
         XCTAssertEqual(mockRepository.pinSubmitted.pin, expectedPin)
         XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
+    }
+
+    func testSubmittingPinWithErrorForwardsErrorToCardContainer() async {
+        let expectedErrorMessage = "Error Message"
+        let expectedError: PaystackError = .response(code: 400, message: expectedErrorMessage)
+        mockRepository.expectedErrorResponse = expectedError
+
+        serviceUnderTest.pinText = "1234"
+        await serviceUnderTest.submitPin()
+
+        XCTAssertEqual(mockChargeCardContainer.transactionError,
+            .paystackResponse(message: expectedErrorMessage))
     }
 
 }

--- a/Tests/PaystackSDKTests/UI/Charge/TestMode/TestModeCardSelectionViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/TestMode/TestModeCardSelectionViewModelTests.swift
@@ -35,7 +35,7 @@ final class TestModeCardSelectionViewModelTests: XCTestCase {
         XCTAssertTrue(mockChargeCardContainer.cardPaymentRestarted)
     }
 
-    func testSubmittingTestardDetailsBuildsCardModelAndForwardsRepositoryResponseToContainer() async throws {
+    func testSubmittingTestCardDetailsBuildsCardModelAndForwardsRepositoryResponseToContainer() async throws {
         serviceUnderTest.testCard = .success
 
         mockRepository.expectedChargeCardTransaction = .example
@@ -48,5 +48,17 @@ final class TestModeCardSelectionViewModelTests: XCTestCase {
 
         XCTAssertEqual(mockRepository.cardDetailsSubmitted.card, expectedCard)
         XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
+    }
+
+    func testSubmittingTestCardDetailsWithErrorForwardsErrorToCardContainer() async {
+        let expectedErrorMessage = "Error Message"
+        let expectedError: PaystackError = .response(code: 400, message: expectedErrorMessage)
+        mockRepository.expectedErrorResponse = expectedError
+
+        serviceUnderTest.testCard = .success
+        await serviceUnderTest.proceedWithTestCard()
+
+        XCTAssertEqual(mockChargeCardContainer.transactionError,
+            .paystackResponse(message: expectedErrorMessage))
     }
 }

--- a/Tests/PaystackSDKTests/UI/Models/ChargeErrorTests.swift
+++ b/Tests/PaystackSDKTests/UI/Models/ChargeErrorTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import PaystackCore
+@testable import PaystackUI
+
+final class ChargeErrorTests: PSTestCase {
+
+    func testInitializingWithMessageBuildsErrorAsCustom() {
+        let expectedMessage = "Error Message"
+        let error = ChargeError(message: expectedMessage)
+        XCTAssertEqual(error, .custom(message: expectedMessage))
+    }
+
+    func testInitializingWithNonPaystackErrorBuildsErrorAsGeneric() {
+        let errorResponse = MockError.general
+        let error = ChargeError(error: errorResponse)
+        XCTAssertEqual(error, .generic)
+    }
+
+    func testInitializingWithPaystackErrorWithoutMessageBuildsErrorAsGeneric() {
+        let errorResponse = PaystackError.technical
+        let error = ChargeError(error: errorResponse)
+        XCTAssertEqual(error, .generic)
+    }
+
+    func testInitializingWithPaystackErrorWithMessageBuildsErrorAsPaystackResponse() {
+        let expectedMessage = "Error Message"
+        let errorResponse = PaystackError.response(code: 400, message: expectedMessage)
+        let error = ChargeError(error: errorResponse)
+        XCTAssertEqual(error, .paystackResponse(message: expectedMessage))
+    }
+
+}


### PR DESCRIPTION
# Changes:
- Modified the Address, Birthday, OTP, Phone, Pin, Card Details and Test Mode Card Selection View Models to forward a `ChargeError` to the `ChargeCardContainer` for appropriate error handling
- Added unit tests for all the affected view models
- Added unit tests for `ChargeError`