### PR TITLE
Refactored birthday endpoint to take a date object

### DIFF
--- a/Sources/PaystackSDK/API/Charge/Charge.swift
+++ b/Sources/PaystackSDK/API/Charge/Charge.swift
@@ -43,12 +43,13 @@ public extension Paystack {
 
     /// Continues the Charge flow by authenticating a user with their birthday
     /// - Parameters:
-    ///   - birthday: The user's birthday in ISO 8601 format
+    ///   - birthday: The user's birthday as a ``Date`` object
     ///   - accessCode: The access code for the current transaction
     /// - Returns: A ``Service`` with the results of the authentication
-    func authenticateCharge(withBirthday birthday: String,
+    func authenticateCharge(withBirthday birthday: Date,
                             accessCode: String) -> Service<ChargeResponse> {
-        let request = SubmitBirthdayRequest(birthday: birthday, accessCode: accessCode)
+        let birthdayString = DateFormatter.toString(usingFormat: "yyyy-MM-dd", from: birthday)
+        let request = SubmitBirthdayRequest(birthday: birthdayString, accessCode: accessCode)
         return service.postSubmitBirthday(request)
     }
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
@@ -27,14 +27,23 @@ class CardBirthdayViewModel: ObservableObject {
 
     func submitBirthday() async {
         do {
-            let formattedBirthday = "\(year)-\(month?.formattedRepresentation ?? "00")-\(day)"
+            let birthday = try constructBirthday()
             let authenticationResult = try await repository.submitBirthday(
-                formattedBirthday, accessCode: chargeCardContainer.accessCode)
+                birthday, accessCode: chargeCardContainer.accessCode)
             await chargeCardContainer.processTransactionResponse(authenticationResult)
         } catch {
             let error = ChargeError(error: error)
             chargeCardContainer.displayTransactionError(error)
         }
+    }
+
+    private func constructBirthday() throws -> Date {
+        guard let monthString = month?.formattedRepresentation,
+              let date = DateFormatter.toDate(usingFormat: "yy-MM-dd",
+                                              from: "\(year)-\(monthString)-\(day)") else {
+            throw ChargeError.generic
+        }
+        return date
     }
 
     func cancelTransaction() {

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -70,6 +70,7 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
         }
     }
 
+    @MainActor
     func displayTransactionError(_ error: ChargeError) {
         Logger.error("Displaying error: %@", arguments: error.message)
         chargeCardState = .error(error)

--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepository.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepository.swift
@@ -1,9 +1,10 @@
+import Foundation
 import PaystackCore
 
 protocol ChargeCardRepository {
     func submitCardDetails(_ card: CardCharge, publicEncryptionKey: String,
                            accessCode: String) async throws -> ChargeCardTransaction
-    func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction
+    func submitBirthday(_ birthday: Date, accessCode: String) async throws -> ChargeCardTransaction
     func submitPhone(_ phone: String, accessCode: String) async throws -> ChargeCardTransaction
     func submitOTP(_ otp: String, accessCode: String) async throws -> ChargeCardTransaction
     func submitAddress(_ address: Address, accessCode: String) async throws -> ChargeCardTransaction

--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
@@ -1,3 +1,4 @@
+import Foundation
 import PaystackCore
 
 struct ChargeCardRepositoryImplementation: ChargeCardRepository {
@@ -16,7 +17,7 @@ struct ChargeCardRepositoryImplementation: ChargeCardRepository {
         return ChargeCardTransaction.from(response)
     }
 
-    func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction {
+    func submitBirthday(_ birthday: Date, accessCode: String) async throws -> ChargeCardTransaction {
         let response = try await paystack.authenticateCharge(withBirthday: birthday,
                                                              accessCode: accessCode).async()
         return ChargeCardTransaction.from(response)

--- a/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
+++ b/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
@@ -50,7 +50,13 @@ final class ChargeTests: PSTestCase {
             .expectBody(birthdayRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        _ = try serviceUnderTest.authenticateCharge(withBirthday: "1990-01-01", accessCode: "abcde").sync()
+        guard let birthday = DateFormatter.toDate(usingFormat: "yyyy-MM-dd",
+                                                  from: "1990-01-01") else {
+            XCTFail("Failed to construct birthday")
+            return
+        }
+
+        _ = try serviceUnderTest.authenticateCharge(withBirthday: birthday, accessCode: "abcde").sync()
     }
 
     func testAuthenticateChargeWithAddressAuthentication() throws {

--- a/Tests/PaystackSDKTests/UI/Charge/CardBirthday/CardBirthdayViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardBirthday/CardBirthdayViewModelTests.swift
@@ -29,30 +29,41 @@ final class CardBirthdayViewModelTests: XCTestCase {
     }
 
     func testFormIsInvalidWhenSomeFieldsAreEmpty() {
-        serviceUnderTest.year = "2000"
+        serviceUnderTest.year = "00"
         serviceUnderTest.day = "01"
         serviceUnderTest.month = nil
         XCTAssertFalse(serviceUnderTest.isValid)
     }
 
     func testFormIsValidIfAllFieldsAreNotEmpty() {
-        serviceUnderTest.year = "2000"
+        serviceUnderTest.year = "00"
         serviceUnderTest.day = "01"
         serviceUnderTest.month = .january
         XCTAssertTrue(serviceUnderTest.isValid)
     }
 
-    func testSubmittingBirthdayFormatsBirthdayCorrectlyAndSendsRepoResultToCardContainer() async throws {
-        serviceUnderTest.year = "2000"
+    func testSubmittingBirthdayConstructsBirthdayCorrectlyAndSendsRepoResultToCardContainer() async throws {
+        serviceUnderTest.year = "20"
         serviceUnderTest.month = .january
         serviceUnderTest.day = "01"
 
         mockRepository.expectedChargeCardTransaction = .example
         await serviceUnderTest.submitBirthday()
 
-        let expectedBirthdayFormat = "2000-01-01"
-        XCTAssertEqual(mockRepository.birthdaySubmitted.birthday, expectedBirthdayFormat)
+        let birthdayString = DateFormatter.toString(usingFormat: "yyyy-MM-dd",
+                                                    from: mockRepository.birthdaySubmitted.birthday!)
+        XCTAssertEqual(birthdayString, "2020-01-01")
         XCTAssertEqual(mockChargeCardContainer.transactionResponse, .example)
+    }
+
+    func testSubmittingBirthdayThrowsErrorWhenBirthdayIsNotValid() async {
+        serviceUnderTest.year = "123"
+        serviceUnderTest.month = .january
+        serviceUnderTest.day = "01"
+
+        await serviceUnderTest.submitBirthday()
+
+        XCTAssertEqual(mockChargeCardContainer.transactionError, .generic)
     }
 
     func testSubmittingBirthdayWithErrorForwardsErrorToCardContainer() async {

--- a/Tests/PaystackSDKTests/UI/Charge/CardRepository/ChargeCardRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardRepository/ChargeCardRepositoryImplementationTests.swift
@@ -26,7 +26,13 @@ final class ChargeCardRepositoryImplementationTests: PSTestCase {
             .expectBody(birthdayRequestBody)
             .andReturn(json: "ChargeAuthenticationResponse")
 
-        let result = try await serviceUnderTest.submitBirthday("1990-01-01",
+        guard let birthday = DateFormatter.toDate(usingFormat: "yyyy-MM-dd",
+                                                  from: "1990-01-01") else {
+            XCTFail("Failed to construct birthday")
+            return
+        }
+
+        let result = try await serviceUnderTest.submitBirthday(birthday,
                                                                accessCode: "test_access")
         XCTAssertEqual(result, .jsonExample)
     }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -179,9 +179,9 @@ final class ChargeCardViewModelTests: PSTestCase {
         XCTAssertEqual(serviceUnderTest.chargeCardState, .failed)
     }
 
-    func testCallingDisplayTransactionErrorSetsStateToErrorStateWithTheAccompanyingError() {
+    func testCallingDisplayTransactionErrorSetsStateToErrorStateWithTheAccompanyingError() async {
         let error = ChargeError(message: "Test")
-        serviceUnderTest.displayTransactionError(error)
+        await serviceUnderTest.displayTransactionError(error)
         XCTAssertEqual(serviceUnderTest.chargeCardState, .error(error))
     }
 }

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardRepository.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardRepository.swift
@@ -10,7 +10,7 @@ class MockChargeCardRepository: ChargeCardRepository {
 
     var cardDetailsSubmitted: (card: CardCharge?, accessCode: String,
                                publicEncryptionKey: String) = (nil, "", "")
-    var birthdaySubmitted: (birthday: String, accessCode: String) = ("", "")
+    var birthdaySubmitted: (birthday: Date?, accessCode: String) = (nil, "")
     var phoneSubmitted: (phone: String, accessCode: String) = ("", "")
     var otpSubmitted: (otp: String, accessCode: String) = ("", "")
     var addressSubmitted: (address: Address?, accessCode: String) = (nil, "")
@@ -23,7 +23,7 @@ class MockChargeCardRepository: ChargeCardRepository {
         return try await mockedResponse()
     }
 
-    func submitBirthday(_ birthday: String, accessCode: String) async throws -> ChargeCardTransaction {
+    func submitBirthday(_ birthday: Date, accessCode: String) async throws -> ChargeCardTransaction {
         birthdaySubmitted = (birthday, accessCode)
         return try await mockedResponse()
     }


### PR DESCRIPTION
# Discussion:
This is a tricky endpoint, we were previously just taking in a birthday string but that seems rather prone to errors, and it becomes hard to enforce the correct format that we want. Taking in a `Date` ensures that the responsibility is on the developer to provide a valid Date object.

**This is currently just a POC to get thoughts on this change.**

# Changes:
- Modified `authenticateCharge(withBirthday birthday:` in the `Paystack` extension to take a `Date` instead of a string
- Modified `CardBirthdayViewModel` to construct a birthday `Date` to pass to the `Paystack` extension for auth
- Made changes to `ChargeCardRepository` and its implementation to change the type expected
- Updated a number of tests for this change