### PR TITLE
Display BE messages for authentication screens

### DIFF
--- a/Sources/PaystackSDK/Core/Models/Models/Charge/TransactionStatus.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Charge/TransactionStatus.swift
@@ -10,5 +10,5 @@ public enum TransactionStatus: String, Codable {
     case sendPin = "send_pin"
     case sendPhone = "send_phone"
     case sendAddress = "send_address"
-    case redirect
+    case openUrl = "open_url"
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Address/CardAddressView.swift
@@ -6,8 +6,13 @@ struct CardAddressView: View {
     @StateObject
     var viewModel: CardAddressViewModel
 
+    let displayMessage: String
+
     init(states: [String],
+         displayMessage: String?,
          chargeCardContainer: ChargeCardContainer) {
+        self.displayMessage = displayMessage ??
+        "Enter your billing address to complete this payment"
         self._viewModel = StateObject(
             wrappedValue: CardAddressViewModel(states: states,
                                                chargeCardContainer: chargeCardContainer))
@@ -17,7 +22,7 @@ struct CardAddressView: View {
         ScrollView {
             VStack(spacing: .triplePadding) {
 
-                Text("Enter your billing address to complete this payment")
+                Text(displayMessage)
                     .font(.body16M)
                     .foregroundColor(.stackBlue)
                     .multilineTextAlignment(.center)
@@ -72,7 +77,7 @@ struct CardAddressView: View {
 @available(iOS 14.0, *)
 struct CardAddressView_Previews: PreviewProvider {
     static var previews: some View {
-        CardAddressView(states: [],
+        CardAddressView(states: [], displayMessage: nil,
                         chargeCardContainer: ChargeCardViewModel(
                             transactionDetails: .example,
                             chargeContainer: ChargeViewModel(accessCode: "access_code")))

--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayView.swift
@@ -15,7 +15,12 @@ struct CardBirthdayView: View {
     @State
     private var showYearError = false
 
-    init(chargeCardContainer: ChargeCardContainer) {
+    let displayMessage: String
+
+    init(displayMessage: String?,
+         chargeCardContainer: ChargeCardContainer) {
+        self.displayMessage = displayMessage ??
+        "Verify your date of birth to use this bank account with Paystack"
         self._viewModel = StateObject(
             wrappedValue: CardBirthdayViewModel(chargeCardContainer: chargeCardContainer))
     }
@@ -24,7 +29,7 @@ struct CardBirthdayView: View {
         VStack(spacing: .triplePadding) {
             Image.birthdayIcon
 
-            Text("Verify your date of birth to use this bank account with Paystack")
+            Text(displayMessage)
                 .font(.body16M)
                 .foregroundColor(.stackBlue)
                 .multilineTextAlignment(.center)
@@ -76,7 +81,8 @@ struct CardBirthdayView: View {
 @available(iOS 14.0, *)
 struct CardBirthdayView_Previews: PreviewProvider {
     static var previews: some View {
-        CardBirthdayView(chargeCardContainer: ChargeCardViewModel(
+        CardBirthdayView(displayMessage: nil,
+                         chargeCardContainer: ChargeCardViewModel(
             transactionDetails: .example,
             chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -28,19 +28,22 @@ struct ChargeCardView: View {
             CardPinView(encryptionKey: encryptionKey,
                         chargeCardContainer: viewModel)
 
-        case .phoneNumber:
-            CardPhoneView(chargeCardContainer: viewModel)
+        case .phoneNumber(let displayMessage):
+            CardPhoneView(displayMessage: displayMessage,
+                          chargeCardContainer: viewModel)
 
-        case .otp(let phoneNumber):
-            CardOTPVIew(phoneNumber: phoneNumber,
+        case .otp(let displayMessage):
+            CardOTPVIew(displayMessage: displayMessage,
                         chargeCardContainer: viewModel)
 
-        case .address(let states):
+        case .address(let states, let displayMessage):
             CardAddressView(states: states,
+                            displayMessage: displayMessage,
                             chargeCardContainer: viewModel)
 
-        case .birthday:
-            CardBirthdayView(chargeCardContainer: viewModel)
+        case .birthday(let displayMessage):
+            CardBirthdayView(displayMessage: displayMessage,
+                             chargeCardContainer: viewModel)
 
         case .error(let error):
             errorView(message: error.message)

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -43,15 +43,16 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
 
     @MainActor
     func processTransactionResponse(_ response: ChargeCardTransaction) async {
+        let displayText = response.displayText
         switch response.status {
         case .sendAddress:
             await handleSendAddress(with: response)
         case .sendBirthday:
-            chargeCardState = .birthday
+            chargeCardState = .birthday(displayMessage: displayText)
         case .sendPhone:
-            handleSendPhone(with: response)
+            chargeCardState = .phoneNumber(displayMessage: displayText)
         case .sendOtp:
-            handleSendOtp(with: response)
+            chargeCardState = .otp(displayMessage: displayText)
         case .sendPin:
             chargeCardState = .pin(encryptionKey: transactionDetails.publicEncryptionKey)
         case .success:
@@ -61,7 +62,7 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
         case .pending:
             // TODO: Add logic for pending state
             break
-        case .redirect:
+        case .openUrl:
             // TODO: Add logic for 3DS
             break
         case .timeout:
@@ -83,18 +84,6 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
             chargeCardState = .error(.generic)
             return
         }
-        chargeCardState = .address(states: states)
-    }
-
-    private func handleSendPhone(with response: ChargeCardTransaction) {
-        let displayText = response.displayText ??
-        "Please enter your mobile phone number (at least 10 digits)"
-        chargeCardState = .phoneNumber(displayMessage: displayText)
-    }
-
-    private func handleSendOtp(with response: ChargeCardTransaction) {
-        let displayText = response.displayText ??
-        "Please enter the OTP sent to your mobile number"
-        chargeCardState = .otp(displayMessage: displayText)
+        chargeCardState = .address(states: states, displayMessage: response.displayText)
     }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
@@ -4,10 +4,10 @@ enum ChargeCardState {
     case cardDetails(amount: AmountCurrency, encryptionKey: String)
     case testModeCardSelection(amount: AmountCurrency, encryptionKey: String)
     case pin(encryptionKey: String)
-    case phoneNumber(displayMessage: String)
-    case otp(displayMessage: String)
-    case address(states: [String])
-    case birthday
+    case phoneNumber(displayMessage: String?)
+    case otp(displayMessage: String?)
+    case address(states: [String], displayMessage: String?)
+    case birthday(displayMessage: String?)
     case error(ChargeError)
     case failed
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPVIew.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPVIew.swift
@@ -7,10 +7,12 @@ struct CardOTPVIew: View {
     @StateObject
     var viewModel: CardOTPViewModel
 
-    init(phoneNumber: String,
+    let displayMessage: String
+
+    init(displayMessage: String?,
          chargeCardContainer: ChargeCardContainer) {
+        self.displayMessage = displayMessage ?? "Please enter the OTP sent to your mobile number"
         self._viewModel = StateObject(wrappedValue: CardOTPViewModel(
-            phoneNumber: phoneNumber,
             chargeCardContainer: chargeCardContainer))
     }
 
@@ -19,7 +21,7 @@ struct CardOTPVIew: View {
             VStack(spacing: .triplePadding) {
                 Image.otpIcon
 
-                Text("Please enter the OTP sent to \(viewModel.phoneNumber)")
+                Text(displayMessage)
                     .font(.body16M)
                     .foregroundColor(.stackBlue)
                     .multilineTextAlignment(.center)
@@ -48,7 +50,7 @@ struct CardOTPVIew: View {
 @available(iOS 14.0, *)
 struct CardOTPVIew_Previews: PreviewProvider {
     static var previews: some View {
-        CardOTPVIew(phoneNumber: "+234801****5678",
+        CardOTPVIew(displayMessage: nil,
                     chargeCardContainer: ChargeCardViewModel(
                         transactionDetails: .example,
                         chargeContainer: ChargeViewModel(accessCode: "access_code")))

--- a/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/OTP/CardOTPViewModel.swift
@@ -5,15 +5,12 @@ class CardOTPViewModel: ObservableObject {
 
     var chargeCardContainer: ChargeCardContainer
     var repository: ChargeCardRepository
-    var phoneNumber: String
 
     @Published
     var otp: String = ""
 
-    init(phoneNumber: String,
-         chargeCardContainer: ChargeCardContainer,
+    init(chargeCardContainer: ChargeCardContainer,
          repository: ChargeCardRepository = ChargeCardRepositoryImplementation()) {
-        self.phoneNumber = phoneNumber
         self.chargeCardContainer = chargeCardContainer
         self.repository = repository
     }

--- a/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Phone/CardPhoneView.swift
@@ -10,8 +10,12 @@ struct CardPhoneView: View {
 
     @State
     private var showPhoneNumberError = false
+    let displayMessage: String
 
-    init(chargeCardContainer: ChargeCardContainer) {
+    init(displayMessage: String?,
+         chargeCardContainer: ChargeCardContainer) {
+        self.displayMessage = displayMessage ??
+        "Please enter your mobile phone number (at least 10 digits)"
         self._viewModel = StateObject(wrappedValue: CardPhoneViewModel(
             chargeCardContainer: chargeCardContainer))
     }
@@ -20,7 +24,7 @@ struct CardPhoneView: View {
         VStack(spacing: .triplePadding) {
             Image.otpIcon
 
-            Text("Please enter your mobile phone number (at least 10 digits)")
+            Text(displayMessage)
                 .font(.body16M)
                 .foregroundColor(.stackBlue)
                 .multilineTextAlignment(.center)
@@ -51,7 +55,8 @@ struct CardPhoneView: View {
 @available(iOS 14.0, *)
 struct CardPhoneView_Previews: PreviewProvider {
     static var previews: some View {
-        CardPhoneView(chargeCardContainer: ChargeCardViewModel(
+        CardPhoneView(displayMessage: nil,
+                      chargeCardContainer: ChargeCardViewModel(
             transactionDetails: .example,
             chargeContainer: ChargeViewModel(accessCode: "access_code")))
     }

--- a/Tests/PaystackSDKTests/UI/Charge/CardOTP/CardOTPViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardOTP/CardOTPViewModelTests.swift
@@ -7,14 +7,12 @@ final class CardOTPViewModelTests: XCTestCase {
     var serviceUnderTest: CardOTPViewModel!
     var mockChargeCardContainer: MockChargeCardContainer!
     var mockRepository: MockChargeCardRepository!
-    let mockPhoneNumber = "+234801****5678"
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         mockChargeCardContainer = MockChargeCardContainer()
         mockRepository = MockChargeCardRepository()
-        serviceUnderTest = CardOTPViewModel(phoneNumber: mockPhoneNumber,
-                                            chargeCardContainer: mockChargeCardContainer,
+        serviceUnderTest = CardOTPViewModel(chargeCardContainer: mockChargeCardContainer,
                                             repository: mockRepository)
     }
 

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -18,7 +18,7 @@ final class ChargeCardViewModelTests: PSTestCase {
     }
 
     func testRestartCardPaymentResetsStateToCardDetailsWithAmount() {
-        serviceUnderTest.chargeCardState = .birthday
+        serviceUnderTest.chargeCardState = .birthday(displayMessage: "Test")
         serviceUnderTest.restartCardPayment()
         XCTAssertEqual(serviceUnderTest.chargeCardState,
                        .cardDetails(amount: mockTransactionDetails.amountCurrency,
@@ -95,13 +95,17 @@ final class ChargeCardViewModelTests: PSTestCase {
     }
 
     func testProcessResponseWithAddressStatusSetsStateToAddressAndFetchesAddreses() async {
-        let addressResponse = ChargeCardTransaction(status: .sendAddress, countryCode: "US")
+        let expectedDisplayText = "Test Display Text"
+        let addressResponse = ChargeCardTransaction(status: .sendAddress,
+                                                    displayText: expectedDisplayText,
+                                                    countryCode: "US")
         let mockStates = ["Test State A", "Test State B"]
 
         mockRepository.expectedAddressStates = mockStates
 
         await serviceUnderTest.processTransactionResponse(addressResponse)
-        XCTAssertEqual(serviceUnderTest.chargeCardState, .address(states: mockStates))
+        XCTAssertEqual(serviceUnderTest.chargeCardState, .address(states: mockStates,
+                                                                  displayMessage: expectedDisplayText))
     }
 
     func testProcessResponseWithAddressStatusSetsStatusToGenericErrorIfCountryCodeIsNotPresent() async {
@@ -122,9 +126,12 @@ final class ChargeCardViewModelTests: PSTestCase {
     }
 
     func testProcessResponseWithBirthdayStatusSetsStateToBirthday() async {
-        let birthdayResponse = ChargeCardTransaction(status: .sendBirthday)
+        let expectedDisplayText = "Test Display Text"
+        let birthdayResponse = ChargeCardTransaction(status: .sendBirthday,
+                                                     displayText: expectedDisplayText)
         await serviceUnderTest.processTransactionResponse(birthdayResponse)
-        XCTAssertEqual(serviceUnderTest.chargeCardState, .birthday)
+        XCTAssertEqual(serviceUnderTest.chargeCardState,
+            .birthday(displayMessage: expectedDisplayText))
     }
 
     func testProcessResponseWithPhoneStatusSetsStateToPhone() async {
@@ -136,28 +143,12 @@ final class ChargeCardViewModelTests: PSTestCase {
             .phoneNumber(displayMessage: expectedDisplayText))
     }
 
-    func testProcessResponseWithPhoneStatusDisplaysAGenericDisplayMessageWhenDisplayTextIsNull() async {
-        let genericExpectedOTPMessage = "Please enter your mobile phone number (at least 10 digits)"
-        let otpResponse = ChargeCardTransaction(status: .sendPhone)
-        await serviceUnderTest.processTransactionResponse(otpResponse)
-        XCTAssertEqual(serviceUnderTest.chargeCardState,
-            .phoneNumber(displayMessage: genericExpectedOTPMessage))
-    }
-
     func testProcessResponseWithOTPStatusSetsStateToOTP() async {
         let expectedDisplayText = "Test Display Text"
         let otpResponse = ChargeCardTransaction(status: .sendOtp, displayText: expectedDisplayText)
         await serviceUnderTest.processTransactionResponse(otpResponse)
         XCTAssertEqual(serviceUnderTest.chargeCardState,
             .otp(displayMessage: expectedDisplayText))
-    }
-
-    func testProcessResponseWithOTPStatusDisplaysAGenericDisplayMessageWhenDisplayTextIsNull() async {
-        let genericExpectedOTPMessage = "Please enter the OTP sent to your mobile number"
-        let otpResponse = ChargeCardTransaction(status: .sendOtp)
-        await serviceUnderTest.processTransactionResponse(otpResponse)
-        XCTAssertEqual(serviceUnderTest.chargeCardState,
-            .otp(displayMessage: genericExpectedOTPMessage))
     }
 
     func testProcessResponseWithPinStatusSetsStateToPin() async {


### PR DESCRIPTION
# Changes:
- Renamed `redirect` to `openUrl` in `TransactionStatus`
-  Modified `ChargeCardState` to pass display messages to more states that need it
- Updated `CardAddressView`, `CardBirthdayView `, `CardOTPVIew `, `CardPhoneVIew` to all take a nullable message in their intiializer, provide some default text if the message is null and display that as the title of the view
- Passed the message along in `ChargeCardViewModel` as necessary
- Updated unit tests

Note: The decision to move the default text from the parent view model to instead live inside each child view was intentional as it seemed like a better practice