### PR TITLE
Requery transaction for pending state

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -14,6 +14,9 @@ struct ChargeCardView: View {
 
     var body: some View {
         switch viewModel.chargeCardState {
+        case .loading(let message):
+            LoadingView(message: message)
+
         case .cardDetails(let amount, let encryptionKey):
             CardDetailsView(amountDetails: amount,
                             encryptionKey: encryptionKey,

--- a/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Models/ChargeCardState.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum ChargeCardState {
+    case loading(message: String? = nil)
     case cardDetails(amount: AmountCurrency, encryptionKey: String)
     case testModeCardSelection(amount: AmountCurrency, encryptionKey: String)
     case pin(encryptionKey: String)

--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepository.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepository.swift
@@ -12,4 +12,5 @@ protocol ChargeCardRepository {
                    accessCode: String) async throws -> ChargeCardTransaction
     func getAddressStates(for countryCode: String) async throws -> [String]
     func listenFor3DS(for transactionId: Int) async throws -> ChargeCardTransaction
+    func checkPendingCharge(with accessCode: String) async throws -> ChargeCardTransaction
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Repository/ChargeCardRepositoryImplementation.swift
@@ -59,4 +59,9 @@ struct ChargeCardRepositoryImplementation: ChargeCardRepository {
         let response = try await paystack.listenFor3DSResponse(for: transactionId).async()
         return ChargeCardTransaction.from(response)
     }
+
+    func checkPendingCharge(with accessCode: String) async throws -> ChargeCardTransaction {
+        let response = try await paystack.checkPendingCharge(forAccessCode: accessCode).async()
+        return ChargeCardTransaction.from(response)
+    }
 }

--- a/Tests/PaystackSDKTests/API/Transactions/TransactionsTests.swift
+++ b/Tests/PaystackSDKTests/API/Transactions/TransactionsTests.swift
@@ -24,7 +24,7 @@ class TransactionsTests: PSTestCase {
         _ = try await serviceUnderTest.verifyAccessCode("access_code_test").async()
     }
 
-    func testChechPendingCharge() async throws {
+    func testCheckPendingCharge() async throws {
         mockServiceExecutor
             .expectURL("https://api.paystack.co/transaction/charge/access_code_test")
             .expectMethod(.get)

--- a/Tests/PaystackSDKTests/UI/Charge/CardRepository/ChargeCardRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardRepository/ChargeCardRepositoryImplementationTests.swift
@@ -83,6 +83,17 @@ final class ChargeCardRepositoryImplementationTests: PSTestCase {
         XCTAssertEqual(result, .jsonExample)
     }
 
+    func testCheckPendingChargeSubmitsRequestUsingPaystackObjectAndMapsCorrectlyToModel() async throws {
+        mockServiceExecutor
+            .expectURL("https://api.paystack.co/transaction/charge/access_code_test")
+            .expectMethod(.get)
+            .expectHeader("Authorization", "Bearer \(apiKey)")
+            .andReturn(json: "ChargeAuthenticationResponse")
+
+        let result = try await serviceUnderTest.checkPendingCharge(with: "access_code_test")
+        XCTAssertEqual(result, .jsonExample)
+    }
+
     func testListenFor3DSResponseListensUsingThePaystackObjectAndMapsCorrectlyToModel() async throws {
         let transactionId = 1234
         let mockSubscription = PusherSubscription(channelName: "3DS_\(transactionId)",

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -234,6 +234,17 @@ final class ChargeCardViewModelTests: PSTestCase {
                        .fatalError(error: .generic))
     }
 
+    func testProcessResponseWithPendingUrlChecksPendingChargeStatusAndUpdatesWithTheNewStatus() async {
+        let pendingResponse = ChargeCardTransaction(status: .pending)
+
+        let expectedOTPDisplayText = "Test Display Text"
+        let otpResponse = ChargeCardTransaction(status: .sendOtp, displayText: expectedOTPDisplayText)
+        mockRepository.expectedChargeCardTransaction = otpResponse
+
+        await serviceUnderTest.processTransactionResponse(pendingResponse)
+        XCTAssertEqual(serviceUnderTest.chargeCardState, .otp(displayMessage: expectedOTPDisplayText))
+    }
+
     func testCallingDisplayTransactionErrorSetsStateToErrorStateWithTheAccompanyingError() async {
         let error = ChargeError(message: "Test")
         await serviceUnderTest.displayTransactionError(error)

--- a/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardRepository.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/Mocks/MockChargeCardRepository.swift
@@ -17,6 +17,7 @@ class MockChargeCardRepository: ChargeCardRepository {
     var pinSubmitted: (pin: String, accessCode: String,
                        publicEncryptionKey: String) = ("", "", "")
     var redirectTranactionId: Int?
+    var pendingChargeAccessCode: String?
 
     func submitCardDetails(_ card: CardCharge, publicEncryptionKey: String,
                            accessCode: String) async throws -> ChargeCardTransaction {
@@ -59,6 +60,11 @@ class MockChargeCardRepository: ChargeCardRepository {
 
     func listenFor3DS(for transactionId: Int) async throws -> ChargeCardTransaction {
         self.redirectTranactionId = transactionId
+        return try await mockedResponse()
+    }
+
+    func checkPendingCharge(with accessCode: String) async throws -> ChargeCardTransaction {
+        pendingChargeAccessCode = accessCode
         return try await mockedResponse()
     }
 


### PR DESCRIPTION
# Changes:
- Added a `loading` state to `ChargeCardState`
- Added logic to `ChargeCardView` to display the `LoadingView` for the `loading` state
- Added some logic to `ChargeCardViewModel` to set the state to loading if state is pending and then run check pending charge, and update the state again afterwards
- Added `checkPendingCharge` to the repository to call the Core function
- Added unit tests