### PR TITLE
Handle unsupported channels and added pending delay

### DIFF
--- a/Sources/PaystackSDK/Core/Models/Models/Channel.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Channel.swift
@@ -13,4 +13,11 @@ public enum Channel: String, Codable {
     case ussd = "ussd"
     case qr = "qr"
     case bankTransfer = "bank_transfer"
+    case unsupportedChannel
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawString = try container.decode(String.self)
+        self = Channel(rawValue: rawString) ?? .unsupportedChannel
+    }
 }

--- a/Sources/PaystackSDK/Core/Models/Models/VerifyAccessCode/VerifyAccessCodeData.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/VerifyAccessCode/VerifyAccessCodeData.swift
@@ -10,7 +10,7 @@ public struct VerifyAccessCodeData: Decodable {
     public var merchantName: String
     public var domain: Domain
     public var currency: String
-    public var channels: [Channel?]
+    public var channels: [Channel]
     public var channelOptions: ChannelOptions
     public var publicEncryptionKey: String
 

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -10,6 +10,8 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
     var chargeContainer: ChargeContainer
     var repository: ChargeCardRepository
 
+    var checkPendingChargeDelay: UInt64 = 5_000_000_000
+
     init(transactionDetails: VerifyAccessCode,
          chargeContainer: ChargeContainer,
          repository: ChargeCardRepository = ChargeCardRepositoryImplementation()) {
@@ -102,6 +104,7 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
     private func checkPendingCharge() async {
         do {
             chargeCardState = .loading(message: "Checking transaction status")
+            try await Task.sleep(nanoseconds: checkPendingChargeDelay)
             let authenticationResult = try await repository.checkPendingCharge(
                 with: transactionDetails.accessCode)
             await processTransactionResponse(authenticationResult)

--- a/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
+++ b/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
@@ -22,7 +22,7 @@ extension VerifyAccessCode {
         VerifyAccessCode(amount: response.data.amount,
                          currency: response.data.currency,
                          accessCode: response.data.accessCode,
-                         paymentChannels: response.data.channels.compactMap {$0},
+                         paymentChannels: response.data.channels.filter { $0 != .unsupportedChannel },
                          domain: response.data.domain,
                          merchantName: response.data.merchantName,
                          publicEncryptionKey: response.data.publicEncryptionKey,

--- a/Tests/PaystackSDKTests/API/Transactions/Resources/VerifyAccessCode.json
+++ b/Tests/PaystackSDKTests/API/Transactions/Resources/VerifyAccessCode.json
@@ -14,7 +14,8 @@
     "channels": [
       "card",
       "qr",
-      "ussd"
+      "ussd",
+      "eft"
     ],
     "channel_options": {
       "qr": [

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -241,6 +241,7 @@ final class ChargeCardViewModelTests: PSTestCase {
         let otpResponse = ChargeCardTransaction(status: .sendOtp, displayText: expectedOTPDisplayText)
         mockRepository.expectedChargeCardTransaction = otpResponse
 
+        serviceUnderTest.checkPendingChargeDelay = 0
         await serviceUnderTest.processTransactionResponse(pendingResponse)
         XCTAssertEqual(serviceUnderTest.chargeCardState, .otp(displayMessage: expectedOTPDisplayText))
     }


### PR DESCRIPTION
# Changes:
- Added `unsupportedChannel` as a case to `PaymentChannel` and added a custom decoding function to set it as unsupported channel when no match is found
- Added a `checkPendingChargeDelay` delay of 5 seconds and added handling to add the delay before calling check pending charge
- Added logic to `VerifyAccessCode` (the internal model) to filter out any unsupported channels
- Updated unit tests and mocks for the above 