### PR TITLE
Refactored error handling

### DIFF
--- a/Sources/PaystackSDK/Core/PaystackError.swift
+++ b/Sources/PaystackSDK/Core/PaystackError.swift
@@ -1,7 +1,21 @@
 import Foundation
 
-public enum PaystackError: Error, Equatable {
+public enum PaystackError: LocalizedError, Equatable {
     case noAPIKey
     case technical
     case response(code: Int, message: String)
+    case custom(message: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .noAPIKey:
+            return "No API key was provided to initialize the SDK"
+        case .technical:
+            return "A technical error occurred. Please contact Paystack."
+        case .response(let code, let message):
+            return "Error response received with Code: \(code) and Message: \(message)"
+        case .custom(let message):
+            return message
+        }
+    }
 }

--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardViewModel.swift
@@ -73,7 +73,7 @@ class ChargeCardViewModel: ObservableObject, ChargeCardContainer {
 
     @MainActor
     func displayTransactionError(_ error: ChargeError) {
-        Logger.error("Displaying error: %@", arguments: error.message)
+        Logger.error("Displaying error: %@", arguments: error.localizedDescription)
         chargeCardState = .error(error)
     }
 

--- a/Sources/PaystackUI/Charge/ChargeViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeViewModel.swift
@@ -23,15 +23,20 @@ class ChargeViewModel: ObservableObject {
             transactionState = .loading()
             let accessCodeResponse = try await repository.verifyAccessCode(accessCode)
             guard accessCodeResponse.paymentChannels.contains(where: { $0 == .card }) else {
-                let errorMessage = "Card payments are not supported. " +
+                let message = "Card payments are not supported. " +
                 "Please reach out to your merchant for further information"
-                throw ChargeError(message: errorMessage)
+                let cause = "There are currently no payment channels on " +
+                "your integration that are supported by the SDK"
+                throw ChargeError(displayMessage: message, causeMessage: cause)
             }
 
             self.transactionDetails = accessCodeResponse
             transactionState = .payment(type: .card(transactionInformation: accessCodeResponse))
         } catch {
             let error = ChargeError(error: error)
+            Logger.error("Verify access code failed with error: %@",
+                         arguments: error.cause?.localizedDescription ?? "Unknown")
+            // TODO: Display a fatal error here in the future instead
             transactionState = .error(error)
         }
     }

--- a/Sources/PaystackUI/Charge/Models/ChargeError.swift
+++ b/Sources/PaystackUI/Charge/Models/ChargeError.swift
@@ -1,19 +1,21 @@
 import PaystackCore
 
 public struct ChargeError: Error {
-    public var innerError: Error?
+    public var cause: Error?
     public var message: String
+
+    private static var genericErrorMessage = "Something went wrong"
 
     init(error: Error) {
         if let error = error as? ChargeError {
             self = error
         } else if let error = error as? PaystackError,
                   case let .response(_, message) = error {
-            self.innerError = error
+            self.cause = error
             self.message = message
         } else {
-            self.innerError = error
-            self.message = "Something went wrong"
+            self.cause = error
+            self.message = Self.genericErrorMessage
         }
     }
 
@@ -21,8 +23,21 @@ public struct ChargeError: Error {
         self.message = message
     }
 
+    /// Initializes a ChargeError with a seperate display message and cause message that will be initialized as a custom `PaystackError`
+    /// This will cause an error to be marked as fatal and will terminate the payment flow
+    init(displayMessage: String,
+         causeMessage: String) {
+        self.message = displayMessage
+        self.cause = PaystackError.custom(message: causeMessage)
+    }
+
     static var generic: Self {
-        .init(message: "Something went wrong")
+        .init(message: Self.genericErrorMessage)
+    }
+
+    static func generic(withCause cause: String) -> Self {
+        .init(displayMessage: Self.genericErrorMessage,
+              causeMessage: cause)
     }
 
 }
@@ -33,4 +48,11 @@ extension ChargeError: Equatable {
         lhs.message == rhs.message
     }
 
+}
+
+// MARK: - Internal extension for determining fatality
+extension ChargeError {
+    var isFatal: Bool {
+        cause != nil
+    }
 }

--- a/Tests/PaystackSDKTests/UI/Models/ChargeErrorTests.swift
+++ b/Tests/PaystackSDKTests/UI/Models/ChargeErrorTests.swift
@@ -10,6 +10,15 @@ final class ChargeErrorTests: PSTestCase {
         XCTAssertEqual(error, .init(message: expectedMessage))
     }
 
+    func testInitializingWithMessageAndCause() {
+        let expectedMessage = "Error Message"
+        let expectedCauseMessage = "Cause Message"
+
+        let error = ChargeError(displayMessage: expectedMessage, causeMessage: expectedCauseMessage)
+        XCTAssertEqual(error.message, expectedMessage)
+        XCTAssertEqual(error.cause?.localizedDescription, expectedCauseMessage)
+    }
+
     func testInitializingWithChargeErrorInitializesAsSelf() {
         let expectedMessage = "Error Message"
         let chargeError = ChargeError(message: expectedMessage)
@@ -21,14 +30,14 @@ final class ChargeErrorTests: PSTestCase {
         let errorResponse = MockError.general
         let error = ChargeError(error: errorResponse)
         XCTAssertEqual(error.message, "Something went wrong")
-        XCTAssertEqual(error.innerError as? MockError, errorResponse)
+        XCTAssertEqual(error.cause as? MockError, errorResponse)
     }
 
     func testInitializingWithPaystackErrorWithoutMessageAddsErrorToInnerErrorAndSetsGenericMessage() {
         let errorResponse = PaystackError.technical
         let error = ChargeError(error: errorResponse)
         XCTAssertEqual(error.message, "Something went wrong")
-        XCTAssertEqual(error.innerError as? PaystackError, errorResponse)
+        XCTAssertEqual(error.cause as? PaystackError, errorResponse)
     }
 
     func testInitializingWithPaystackErrorWithMessageAddsErrorToInnerErrorAndSetsMessage() {
@@ -36,7 +45,7 @@ final class ChargeErrorTests: PSTestCase {
         let errorResponse = PaystackError.response(code: 400, message: expectedMessage)
         let error = ChargeError(error: errorResponse)
         XCTAssertEqual(error.message, expectedMessage)
-        XCTAssertEqual(error.innerError as? PaystackError, errorResponse)
+        XCTAssertEqual(error.cause as? PaystackError, errorResponse)
     }
 
 }


### PR DESCRIPTION
**A slight refactor of error handling**

# Changes:
- Modified `PaystackError` to contain a `custom` case for initializing custom errors with custom messages
- Changed the type of `PaystackError` to be `LocalizedError` and added an errorDescription
- Also made changes to `ChargeError` to allow it to be initialzied with a cause message as well, making it simpler to create useful error messages
- Changed the Logger functionality in `ChargeCardViewModel` to use `localizedDescription` to log a more useful error
- Updated `ChargeViewModel` to construct different display and cause messages for when card is not part of the supported payment channels to throw a more useful error
- Added Logging to the error in `ChargeViewModel` as well
- Updated unit tests