### PR TITLE
Fixed birthday format 

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Birthday/CardBirthdayViewModel.swift
@@ -39,9 +39,9 @@ class CardBirthdayViewModel: ObservableObject {
 
     private func constructBirthday() throws -> Date {
         guard let monthString = month?.formattedRepresentation,
-              let date = DateFormatter.toDate(usingFormat: "yy-MM-dd",
+              let date = DateFormatter.toDate(usingFormat: "yyyy-MM-dd",
                                               from: "\(year)-\(monthString)-\(day)") else {
-            throw ChargeError.generic
+            throw ChargeError(message: "Invalid Birthday entered")
         }
         return date
     }

--- a/Tests/PaystackSDKTests/UI/Charge/CardBirthday/CardBirthdayViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/CardBirthday/CardBirthdayViewModelTests.swift
@@ -29,21 +29,21 @@ final class CardBirthdayViewModelTests: XCTestCase {
     }
 
     func testFormIsInvalidWhenSomeFieldsAreEmpty() {
-        serviceUnderTest.year = "00"
+        serviceUnderTest.year = "2000"
         serviceUnderTest.day = "01"
         serviceUnderTest.month = nil
         XCTAssertFalse(serviceUnderTest.isValid)
     }
 
     func testFormIsValidIfAllFieldsAreNotEmpty() {
-        serviceUnderTest.year = "00"
+        serviceUnderTest.year = "2000"
         serviceUnderTest.day = "01"
         serviceUnderTest.month = .january
         XCTAssertTrue(serviceUnderTest.isValid)
     }
 
     func testSubmittingBirthdayConstructsBirthdayCorrectlyAndSendsRepoResultToCardContainer() async throws {
-        serviceUnderTest.year = "20"
+        serviceUnderTest.year = "2020"
         serviceUnderTest.month = .january
         serviceUnderTest.day = "01"
 


### PR DESCRIPTION
# Notes:
Somehow had an incorrect birthday formatting in the `BirthdayViewModel` by assuming we entered date as 2 digits. Changed this to use a 4 digit year instead of a 2 digit one.
Also added a more descriptive error to be thrown