### PR TITLE
MOB-811 MOB-810 Fix 3DS Issues

### DIFF
--- a/Sources/PaystackSDK/Core/Models/Models/Charge/ChargeResponseData.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Charge/ChargeResponseData.swift
@@ -12,7 +12,7 @@ public struct ChargeResponseData: Codable {
     public var ussdCode: String?
     public var qrCode: String?
     public var displayText: String?
-    public var metadata: [String: String]?
+    public var metadata: Metadata?
     public var gatewayResponse: String?
     public var message: String?
     public var channel: String?

--- a/Sources/PaystackUI/Charge/ChargeCard/Redirect/CardRedirectView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Redirect/CardRedirectView.swift
@@ -8,6 +8,9 @@ struct CardRedirectView: View {
     @StateObject
     var viewModel: CardRedirectViewModel
 
+    @State
+    var webviewLoading = false
+
     init(urlString: String,
          transactionId: Int,
          chargeCardContainer: ChargeCardContainer) {
@@ -18,9 +21,21 @@ struct CardRedirectView: View {
 
     var body: some View {
         if viewModel.displayWebview {
-            WebView(url: URL(string: urlString))
+            webview
         } else {
             authenticationInitializationView
+        }
+    }
+
+    var webview: some View {
+        ZStack {
+            WebView(url: URL(string: urlString),
+                    isLoading: $webviewLoading)
+
+            if webviewLoading {
+                LoadingIndicator(tintColor: .navy04)
+                    .scaleEffect(2)
+            }
         }
     }
 


### PR DESCRIPTION
# Disclaimer:
This Webview can probably be cleaned up a bit, it's trying to be a jack of all trades right now as it was adapted from somewhere. We should either let it specifically cater to what we want it to do or if we plan on making it common, make it more generic

# Changes:
- Fixed the Metadata property in the response to use the pre-existing Metadata object created
- Modified `CardRedirectView` to bind a loading variable to be shown over the webview 
- Made significant changes to `WebView` to add the following:
The `isLoading` variable bound above
A Coordinator delegate which listens to the state of the webview and updates the loading variable
An option to `normalizeScaling` which fixes a bug of pages looking smaller on WKWebview than they do on UIWebview

# Visual:

![Simulator Screen Recording - iPhone 14 Pro - 2023-09-22 at 02 03 39](https://github.com/PaystackHQ/paystack-sdk-ios/assets/112851169/905f276e-4e34-4953-aafc-807ce19d844e)

