### PR TITLE
Add reference to transaction result details

### DIFF
--- a/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
+++ b/Sources/PaystackUI/Charge/ChargeCard/Container/ChargeCardView.swift
@@ -58,7 +58,9 @@ struct ChargeCardView: View {
 
         case .fatalError(let error):
             ErrorView(message: error.message,
-                      automaticallyDismissWithError: error)
+                      automaticallyDismissWith: .init(
+                        error: error,
+                        transactionReference: viewModel.transactionDetails.reference))
 
         case .failed(let message):
             errorView(message: message ?? "Declined")

--- a/Sources/PaystackUI/Charge/ChargeView.swift
+++ b/Sources/PaystackUI/Charge/ChargeView.swift
@@ -33,8 +33,9 @@ struct ChargeView: View {
                 ErrorView(message: error.message)
             case .payment(let type):
                 paymentFlowView(for: type)
-            case .success(let amount, let merchant):
-                ChargeSuccessView(amount: amount, merchant: merchant)
+            case .success(let amount, let merchant, let details):
+                ChargeSuccessView(amount: amount, merchant: merchant,
+                                  completionDetails: details)
             }
 
             Spacer()
@@ -60,7 +61,11 @@ struct ChargeView: View {
     func chargeCancelled() {
         switch viewModel.transactionState {
         case .success:
-            visibilityContainer.completeAndDismiss(with: .completed)
+            guard let reference = viewModel.transactionDetails?.reference else {
+                Logger.error("Transaction details could not be found")
+                return
+            }
+            visibilityContainer.completeAndDismiss(with: .completed(.init(reference: reference)))
         default:
             visibilityContainer.cancelAndDismiss()
         }

--- a/Sources/PaystackUI/Charge/ChargeViewModel.swift
+++ b/Sources/PaystackUI/Charge/ChargeViewModel.swift
@@ -47,7 +47,9 @@ class ChargeViewModel: ObservableObject {
 extension ChargeViewModel: ChargeContainer {
 
     func processSuccessfulTransaction(details: VerifyAccessCode) {
-        transactionState = .success(amount: details.amountCurrency, merchant: details.merchantName)
+        transactionState = .success(amount: details.amountCurrency,
+                                    merchant: details.merchantName,
+                                    details: .init(reference: details.reference))
     }
 
 }

--- a/Sources/PaystackUI/Charge/Models/ChargeCompletionDetails.swift
+++ b/Sources/PaystackUI/Charge/Models/ChargeCompletionDetails.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct ChargeCompletionDetails {
+
+    /// A reference to the completed Charge. Used to verify the status of the transaction
+    public var reference: String
+}

--- a/Sources/PaystackUI/Charge/Models/ChargeErrorDetails.swift
+++ b/Sources/PaystackUI/Charge/Models/ChargeErrorDetails.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct ChargeErrorDetails {
+    var error: ChargeError
+    var transactionReference: String?
+}

--- a/Sources/PaystackUI/Charge/Models/ChargeState.swift
+++ b/Sources/PaystackUI/Charge/Models/ChargeState.swift
@@ -5,5 +5,6 @@ enum ChargeState {
     case loading(message: String? = nil)
     case payment(type: ChargePaymentType)
     case error(ChargeError)
-    case success(amount: AmountCurrency, merchant: String)
+    case success(amount: AmountCurrency, merchant: String,
+                 details: ChargeCompletionDetails)
 }

--- a/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
+++ b/Sources/PaystackUI/Charge/Models/VerifyAccessCode.swift
@@ -9,6 +9,7 @@ struct VerifyAccessCode: Equatable {
     var domain: Domain
     var merchantName: String
     var publicEncryptionKey: String
+    var reference: String
     var transactionId: Int?
 
     var amountCurrency: AmountCurrency {
@@ -26,6 +27,7 @@ extension VerifyAccessCode {
                          domain: response.data.domain,
                          merchantName: response.data.merchantName,
                          publicEncryptionKey: response.data.publicEncryptionKey,
+                         reference: response.data.reference,
                          transactionId: response.data.id)
     }
 
@@ -40,6 +42,7 @@ extension VerifyAccessCode {
               paymentChannels: [.card],
               domain: .test,
               merchantName: "Test Merchant",
-              publicEncryptionKey: "test_encryption_key")
+              publicEncryptionKey: "test_encryption_key",
+              reference: "test_reference")
     }
 }

--- a/Sources/PaystackUI/Charge/Success/ChargeSuccessView.swift
+++ b/Sources/PaystackUI/Charge/Success/ChargeSuccessView.swift
@@ -5,6 +5,7 @@ struct ChargeSuccessView: View {
 
     let amount: AmountCurrency
     let merchant: String
+    let completionDetails: ChargeCompletionDetails
 
     @EnvironmentObject
     var visibilityContainer: ViewVisibilityContainer
@@ -26,7 +27,7 @@ struct ChargeSuccessView: View {
 
     func dismissAutomatically() async {
         try? await Task.sleep(nanoseconds: 1_500_000_000)
-        visibilityContainer.completeAndDismiss(with: .completed)
+        visibilityContainer.completeAndDismiss(with: .completed(completionDetails))
     }
 }
 
@@ -34,6 +35,7 @@ struct ChargeSuccessView: View {
 struct ChargeSuccessView_Previews: PreviewProvider {
     static var previews: some View {
         ChargeSuccessView(amount: .init(amount: 10000, currency: "USD"),
-                          merchant: "Merchant")
+                          merchant: "Merchant",
+                          completionDetails: .init(reference: "testReference"))
     }
 }

--- a/Sources/PaystackUI/Components/ErrorView.swift
+++ b/Sources/PaystackUI/Components/ErrorView.swift
@@ -6,7 +6,7 @@ struct ErrorView: View {
     var message: String
     var buttonText: String?
     var buttonAction: (() -> Void)?
-    var dismissWithError: ChargeError?
+    var dismissWithError: ChargeErrorDetails?
 
     @EnvironmentObject
     var visibilityContainer: ViewVisibilityContainer
@@ -14,11 +14,11 @@ struct ErrorView: View {
     init(message: String,
          buttonText: String? = nil,
          buttonAction: (() -> Void)? = nil,
-         automaticallyDismissWithError error: ChargeError? = nil) {
+         automaticallyDismissWith errorDetails: ChargeErrorDetails? = nil) {
         self.message = message
         self.buttonText = buttonText
         self.buttonAction = buttonAction
-        self.dismissWithError = error
+        self.dismissWithError = errorDetails
     }
 
     var body: some View {
@@ -41,9 +41,10 @@ struct ErrorView: View {
     }
 
     func dismissIfNecessary() async {
-        guard let error = dismissWithError else { return }
+        guard let errorDetails = dismissWithError else { return }
         try? await Task.sleep(nanoseconds: 3_000_000_000)
-        visibilityContainer.completeAndDismiss(with: .error(error))
+        visibilityContainer.completeAndDismiss(with: .error(error: errorDetails.error,
+                                                            reference: errorDetails.transactionReference))
     }
 }
 

--- a/Sources/PaystackUI/Models/TransactionResult.swift
+++ b/Sources/PaystackUI/Models/TransactionResult.swift
@@ -8,11 +8,11 @@ public enum TransactionResult {
     Your server should verify the transaction status and amount before providing value.
     A transaction can be confirmed by using either webhooks or the verify transactions endpoint.
     See [Paystack's docs](https://paystack.com/docs/payments/verify-payments/) */
-    case completed
+    case completed(ChargeCompletionDetails)
 
     /// The customer canceled the payment attempt.
     case cancelled
 
     /// An unexpected error occurred whilst attempting payment.
-    case error(ChargeError)
+    case error(error: ChargeError, reference: String?)
 }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeCard/ChargeCardViewModelTests.swift
@@ -31,7 +31,8 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .live,
                                                          merchantName: "Test Merchant",
-                                                         publicEncryptionKey: "test_encryption_key")
+                                                         publicEncryptionKey: "test_encryption_key",
+                                                         reference: "test_reference")
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
                                                chargeContainer: mockChargeContainer,
                                                repository: mockRepository)
@@ -46,7 +47,8 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .test,
                                                          merchantName: "Test Merchant",
-                                                         publicEncryptionKey: "test_encryption_key")
+                                                         publicEncryptionKey: "test_encryption_key",
+                                                         reference: "test_reference")
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
                                                chargeContainer: mockChargeContainer,
                                                repository: mockRepository)
@@ -61,7 +63,8 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .test,
                                                          merchantName: "Test Merchant",
-                                                         publicEncryptionKey: "test_encryption_key")
+                                                         publicEncryptionKey: "test_encryption_key",
+                                                         reference: "test_reference")
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
                                                chargeContainer: mockChargeContainer,
                                                repository: mockRepository)
@@ -74,7 +77,8 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .live,
                                                          merchantName: "Test Merchant",
-                                                         publicEncryptionKey: "test_encryption_key")
+                                                         publicEncryptionKey: "test_encryption_key",
+                                                         reference: "test_reference")
         serviceUnderTest = ChargeCardViewModel(transactionDetails: transactionDetails,
                                                chargeContainer: mockChargeContainer,
                                                repository: mockRepository)
@@ -87,7 +91,8 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .live,
                                                          merchantName: "Test Merchant",
-                                                         publicEncryptionKey: "test_encryption_key")
+                                                         publicEncryptionKey: "test_encryption_key",
+                                                         reference: "test_reference")
         serviceUnderTest.switchToTestModeCardSelection()
         XCTAssertEqual(serviceUnderTest.chargeCardState,
                        .testModeCardSelection(amount: transactionDetails.amountCurrency,
@@ -190,6 +195,7 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          paymentChannels: [], domain: .test,
                                                          merchantName: "Test Merchant",
                                                          publicEncryptionKey: "test_encryption_key",
+                                                         reference: "test_reference",
                                                          transactionId: expectedTransactionId)
 
         serviceUnderTest.transactionDetails = transactionDetails
@@ -208,6 +214,7 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          paymentChannels: [], domain: .test,
                                                          merchantName: "Test Merchant",
                                                          publicEncryptionKey: "test_encryption_key",
+                                                         reference: "test_reference",
                                                          transactionId: expectedTransactionId)
 
         serviceUnderTest.transactionDetails = transactionDetails
@@ -224,7 +231,8 @@ final class ChargeCardViewModelTests: PSTestCase {
                                                          accessCode: "test_access",
                                                          paymentChannels: [], domain: .test,
                                                          merchantName: "Test Merchant",
-                                                         publicEncryptionKey: "test_encryption_key")
+                                                         publicEncryptionKey: "test_encryption_key",
+                                                         reference: "test_reference")
 
         serviceUnderTest.transactionDetails = transactionDetails
         let redirectResponse = ChargeCardTransaction(status: .openUrl,

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
@@ -29,7 +29,8 @@ final class ChargeRepositoryImplementationTests: PSTestCase {
                                               paymentChannels: [.card, .qr, .ussd],
                                               domain: .test,
                                               merchantName: "Test Merchant",
-                                              publicEncryptionKey: "test_encryption_key")
+                                              publicEncryptionKey: "test_encryption_key",
+                                              reference: "203520101")
 
         XCTAssertEqual(result, expectedResult)
     }

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeViewModelTests.swift
@@ -34,7 +34,8 @@ final class ChargeViewModelTests: PSTestCase {
                                                   paymentChannels: [.ussd],
                                                   domain: .test,
                                                   merchantName: "Test Merchant",
-                                                  publicEncryptionKey: "test_encryption_key")
+                                                  publicEncryptionKey: "test_encryption_key",
+                                                  reference: "test_reference")
         await serviceUnderTest.verifyAccessCodeAndProceedWithCard()
         XCTAssertEqual(serviceUnderTest.transactionState, .error(.init(message: expectedMessage)))
 
@@ -44,8 +45,10 @@ final class ChargeViewModelTests: PSTestCase {
         serviceUnderTest.transactionState = .loading()
         XCTAssertFalse(serviceUnderTest.centerView)
 
-        serviceUnderTest.transactionState = .success(amount: .init(
-            amount: 100, currency: "USD"), merchant: "Test")
+        serviceUnderTest.transactionState = .success(
+            amount: .init(amount: 100, currency: "USD"),
+            merchant: "Test",
+            details: .init(reference: "test"))
         XCTAssertTrue(serviceUnderTest.centerView)
     }
 
@@ -53,8 +56,9 @@ final class ChargeViewModelTests: PSTestCase {
         serviceUnderTest.transactionState = .loading()
         XCTAssertTrue(serviceUnderTest.displayCloseButtonConfirmation)
 
-        serviceUnderTest.transactionState = .success(amount: .init(
-            amount: 100, currency: "USD"), merchant: "Test")
+        serviceUnderTest.transactionState = .success(
+            amount: .init(amount: 100, currency: "USD"),
+            merchant: "Test", details: .init(reference: "test"))
         XCTAssertFalse(serviceUnderTest.displayCloseButtonConfirmation)
     }
 
@@ -63,7 +67,8 @@ final class ChargeViewModelTests: PSTestCase {
                                                     accessCode: "test_access",
                                                     paymentChannels: [], domain: .test,
                                                     merchantName: "Test Merchant",
-                                                    publicEncryptionKey: "test_encryption_key")
+                                                    publicEncryptionKey: "test_encryption_key",
+                                                    reference: "test_reference")
         XCTAssertTrue(serviceUnderTest.inTestMode)
     }
 
@@ -72,7 +77,8 @@ final class ChargeViewModelTests: PSTestCase {
                                                     accessCode: "test_access",
                                                     paymentChannels: [], domain: .live,
                                                     merchantName: "Test Merchant",
-                                                    publicEncryptionKey: "test_encryption_key")
+                                                    publicEncryptionKey: "test_encryption_key",
+                                                    reference: "test_reference")
         XCTAssertFalse(serviceUnderTest.inTestMode)
     }
 
@@ -88,8 +94,8 @@ extension ChargeState: Equatable {
         switch (lhs, rhs) {
         case (.loading, .loading):
             return true
-        case (.success(let firstAmount, let firstMerchant), .success(let secondAmount, let secondMerchant)):
-            return firstAmount == secondAmount && firstMerchant == secondMerchant
+        case (.success(let firstAmount, let firstMerchant, let firstDetails), .success(let secondAmount, let secondMerchant, let secondDetails)):
+            return firstAmount == secondAmount && firstMerchant == secondMerchant && firstDetails == secondDetails
         case (.payment(let first), .payment(let second)):
             return first == second
         case (.error(let first), .error(let second)):
@@ -99,4 +105,10 @@ extension ChargeState: Equatable {
         }
     }
 
+}
+
+extension ChargeCompletionDetails: Equatable {
+    public static func == (lhs: ChargeCompletionDetails, rhs: ChargeCompletionDetails) -> Bool {
+        lhs.reference == rhs.reference
+    }
 }


### PR DESCRIPTION
# Changes:
- Updated `VerifyAccessCode` to be passed in a reference that comes from its original model
- Created `ChargeCompletionDetails`, a container for details we want to pass on a completed result which currently only hold the reference
- Updated `TransactionResult` to include arguments for error and completed (above)
- Updated the `success` state in `ChargeState` to include the `ChargeCompletionDetails`, and then pass it through to `ChargeSuccessView` to be eventually returned
- Also created `ChargeErrorDetails` to follow a similar process with `ErrorView`
- Updated unit tests to account for the changes