### PR TITLE
MOB-875 Adding MobileMoney Charge endpoint

### DIFF
--- a/Example/paystack-sdk-ios/ContentView.swift
+++ b/Example/paystack-sdk-ios/ContentView.swift
@@ -20,15 +20,15 @@ struct ContentView: View {
         }
         .padding()
     }
-    
+
     func paymentDone(_ result: TransactionResult) {
-        
+
         switch result {
         case .completed(let chargeDetails):
             print("Success: Transaction reference : \(chargeDetails.reference)")
-        case .cancelled :
+        case .cancelled:
             print("Transaction was cancelled.")
-        case .error(error: let error, reference: let reference) :
+        case .error(error: let error, reference: let reference):
             print("An error occured with \(reference!) : \(error.message)")
         }
     }

--- a/Example/paystack-sdk-ios/ContentView.swift
+++ b/Example/paystack-sdk-ios/ContentView.swift
@@ -20,8 +20,18 @@ struct ContentView: View {
         }
         .padding()
     }
-
-    func paymentDone(_ result: TransactionResult) {}
+    
+    func paymentDone(_ result: TransactionResult) {
+        
+        switch result {
+        case .completed(let chargeDetails):
+            print("Success: Transaction reference : \(chargeDetails.reference)")
+        case .cancelled :
+            print("Transaction was cancelled.")
+        case .error(error: let error, reference: let reference) :
+            print("An error occured with \(reference!) : \(error.message)")
+        }
+    }
 }
 
 struct ContentView_Previews: PreviewProvider {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
                 .copy("API/Charge/Resources/ChargeAuthenticationResponse.json"),
                 .copy("API/Other/Resources/AddressStatesResponse.json"),
                 .copy("API/Charge/Resources/ChargeMobileMoneyResponse.json")
-                
+
             ])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,9 @@ let package = Package(
             resources: [
                 .copy("API/Transactions/Resources/VerifyAccessCode.json"),
                 .copy("API/Charge/Resources/ChargeAuthenticationResponse.json"),
-                .copy("API/Other/Resources/AddressStatesResponse.json")
+                .copy("API/Other/Resources/AddressStatesResponse.json"),
+                .copy("API/Charge/Resources/ChargeMobileMoneyResponse.json")
+                
             ])
     ]
 )

--- a/Sources/PaystackSDK/API/Charge/Charge.swift
+++ b/Sources/PaystackSDK/API/Charge/Charge.swift
@@ -4,7 +4,7 @@ public extension Paystack {
     private var service: ChargeService {
         return ChargeServiceImplementation(config: config)
     }
-    
+
     private var mobileMoneyService: MobileMoneyService {
         return MobileMoneyServiceImplementation(config: config)
     }
@@ -76,7 +76,7 @@ public extension Paystack {
         let subscription: any Subscription = PusherSubscription(channelName: channelName, eventName: "response")
         return Service(subscription)
     }
-    
+
     /// Listens for a response after presenting a 3DS URL in a webview for authentication
     /// - Parameter transactionId:The ID of the current transaction that is being authenticated
     /// - Returns: A ``Service`` with the results of the authentication
@@ -85,7 +85,7 @@ public extension Paystack {
         let subscription: any Subscription = PusherSubscription(channelName: channelName, eventName: "response")
         return Service(subscription)
     }
-    
+
     /// Initialize Mobile Money charge
     /// - Parameters:
     ///   - mobileMoneyData: The data that needs to be passed in order to do a mobile money charge
@@ -94,5 +94,4 @@ public extension Paystack {
         let request = MobileMoneyChargeRequest(channelName: mobileMoneyData.channelName, amount: mobileMoneyData.amount, email: mobileMoneyData.email, phone: mobileMoneyData.phone, transaction: mobileMoneyData.transaction, provider: mobileMoneyData.provider)
         return mobileMoneyService.postChargeMobileMoney(request)
     }
-
 }

--- a/Sources/PaystackSDK/API/Charge/Charge.swift
+++ b/Sources/PaystackSDK/API/Charge/Charge.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length type_body_length
 import Foundation
 
 public extension Paystack {
@@ -95,3 +96,4 @@ public extension Paystack {
         return mobileMoneyService.postChargeMobileMoney(request)
     }
 }
+// swiftlint:enable file_length type_body_length

--- a/Sources/PaystackSDK/API/Charge/Charge.swift
+++ b/Sources/PaystackSDK/API/Charge/Charge.swift
@@ -4,6 +4,10 @@ public extension Paystack {
     private var service: ChargeService {
         return ChargeServiceImplementation(config: config)
     }
+    
+    private var mobileMoneyService: MobileMoneyService {
+        return MobileMoneyServiceImplementation(config: config)
+    }
 
     /// Continues the Charge flow by authenticating a user with an OTP
     /// - Parameters:
@@ -71,6 +75,24 @@ public extension Paystack {
         let channelName = "3DS_\(transactionId)"
         let subscription: any Subscription = PusherSubscription(channelName: channelName, eventName: "response")
         return Service(subscription)
+    }
+    
+    /// Listens for a response after presenting a 3DS URL in a webview for authentication
+    /// - Parameter transactionId:The ID of the current transaction that is being authenticated
+    /// - Returns: A ``Service`` with the results of the authentication
+    func listenForMobileMoneyResponse(for transactionId: Int) -> Service<Charge3DSResponse> {
+        let channelName = "MOBILE_MONEY_\(transactionId)"
+        let subscription: any Subscription = PusherSubscription(channelName: channelName, eventName: "response")
+        return Service(subscription)
+    }
+    
+    /// Initialize Mobile Money charge
+    /// - Parameters:
+    ///   - mobileMoneyData: The data that needs to be passed in order to do a mobile money charge
+    /// - Returns: A ``Service`` with the ``MobileMoneyChargeResponse`` response
+    func chargeMobileMoney(with mobileMoneyData: MobileMoneyData) -> Service<MobileMoneyChargeResponse> {
+        let request = MobileMoneyChargeRequest(channelName: mobileMoneyData.channelName, amount: mobileMoneyData.amount, email: mobileMoneyData.email, phone: mobileMoneyData.phone, transaction: mobileMoneyData.transaction, provider: mobileMoneyData.provider)
+        return mobileMoneyService.postChargeMobileMoney(request)
     }
 
 }

--- a/Sources/PaystackSDK/API/Charge/Charge.swift
+++ b/Sources/PaystackSDK/API/Charge/Charge.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length line_length
 import Foundation
 
 public extension Paystack {
@@ -96,4 +96,4 @@ public extension Paystack {
         return mobileMoneyService.postChargeMobileMoney(request)
     }
 }
-// swiftlint:enable file_length type_body_length
+// swiftlint:enable file_length type_body_length line_length

--- a/Sources/PaystackSDK/API/Charge/MobileMoneyService.swift
+++ b/Sources/PaystackSDK/API/Charge/MobileMoneyService.swift
@@ -4,14 +4,14 @@ protocol MobileMoneyService: PaystackService {
     func postChargeMobileMoney(_ request: MobileMoneyChargeRequest) -> Service<MobileMoneyChargeResponse>
 }
 
-struct MobileMoneyServiceImplementation : MobileMoneyService {
-    
+struct MobileMoneyServiceImplementation: MobileMoneyService {
+
     var config: PaystackConfig
 
     var parentPath: String {
         return "charge"
     }
-    
+
     func postChargeMobileMoney(_ request: MobileMoneyChargeRequest) -> Service<MobileMoneyChargeResponse> {
         return post("/mobile_money", request)
             .asService()

--- a/Sources/PaystackSDK/API/Charge/MobileMoneyService.swift
+++ b/Sources/PaystackSDK/API/Charge/MobileMoneyService.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+protocol MobileMoneyService: PaystackService {
+    func postChargeMobileMoney(_ request: MobileMoneyChargeRequest) -> Service<MobileMoneyChargeResponse>
+}
+
+struct MobileMoneyServiceImplementation : MobileMoneyService {
+    
+    var config: PaystackConfig
+
+    var parentPath: String {
+        return "charge"
+    }
+    
+    func postChargeMobileMoney(_ request: MobileMoneyChargeRequest) -> Service<MobileMoneyChargeResponse> {
+        return post("/mobile_money", request)
+            .asService()
+    }
+}

--- a/Sources/PaystackSDK/Core/Models/MobileMoney.swift
+++ b/Sources/PaystackSDK/Core/Models/MobileMoney.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+// MARK: - MobileMoney
+public struct MobileMoney: Codable {
+    let key : String
+    let value: String
+    let isNew: Bool
+    let phoneNumberRegex: String
+}

--- a/Sources/PaystackSDK/Core/Models/MobileMoney.swift
+++ b/Sources/PaystackSDK/Core/Models/MobileMoney.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - MobileMoney
 public struct MobileMoney: Codable {
-    let key : String
+    let key: String
     let value: String
     let isNew: Bool
     let phoneNumberRegex: String

--- a/Sources/PaystackSDK/Core/Models/Models/Channel.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/Channel.swift
@@ -11,6 +11,7 @@ public enum Channel: String, Codable {
     case card = "card"
     case bank = "bank"
     case ussd = "ussd"
+    case mobileMoney = "mobile_money"
     case qr = "qr"
     case bankTransfer = "bank_transfer"
     case unsupportedChannel

--- a/Sources/PaystackSDK/Core/Models/Models/MobileMoneyChargeRequest.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/MobileMoneyChargeRequest.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+// MARK: - MobileMoneyChargeRequest
+struct MobileMoneyChargeRequest: Codable {
+    let channelName: String
+    let amount: Int
+    let email: String
+    let phone: String
+    let transaction: String
+    let provider: String
+}

--- a/Sources/PaystackSDK/Core/Models/Models/MobileMoneyChargeResponse.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/MobileMoneyChargeResponse.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+// MARK: - MobileMoneyChargeResponse
+public struct MobileMoneyChargeResponse: Codable {
+    let status: Bool
+    let message: String
+    let data: MobileMoneyChargeData
+}
+
+// MARK: - MobileMoneyChargeData
+public struct MobileMoneyChargeData: Codable {
+    let transaction, phone, provider, channelName: String
+    let display: Display
+
+    enum CodingKeys: String, CodingKey {
+        case transaction, phone, provider
+        case channelName = "channel_name"
+        case display
+    }
+}
+
+// MARK: - Display
+public struct Display: Codable {
+    let type, message: String
+    let timer: Int
+}

--- a/Sources/PaystackSDK/Core/Models/Models/MobileMoneyChargeResponse.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/MobileMoneyChargeResponse.swift
@@ -14,7 +14,7 @@ public struct MobileMoneyChargeData: Codable {
 
     enum CodingKeys: String, CodingKey {
         case transaction, phone, provider
-        case channelName = "channel_name"
+        case channelName
         case display
     }
 }

--- a/Sources/PaystackSDK/Core/Models/Models/MobileMoneyChargeResponse.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/MobileMoneyChargeResponse.swift
@@ -9,11 +9,16 @@ public struct MobileMoneyChargeResponse: Codable {
 
 // MARK: - MobileMoneyChargeData
 public struct MobileMoneyChargeData: Codable {
-    let transaction, phone, provider, channelName: String
+    let transaction: String
+    let phone: String
+    let provider: String
+    let channelName: String
     let display: Display
 
     enum CodingKeys: String, CodingKey {
-        case transaction, phone, provider
+        case transaction
+        case phone
+        case provider
         case channelName
         case display
     }
@@ -21,6 +26,7 @@ public struct MobileMoneyChargeData: Codable {
 
 // MARK: - Display
 public struct Display: Codable {
-    let type, message: String
+    let type: String
+    let message: String
     let timer: Int
 }

--- a/Sources/PaystackSDK/Core/Models/Models/MobileMoneyData.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/MobileMoneyData.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct MobileMoneyData: Equatable {
+    let channelName: String
+    let amount: Int
+    let email : String
+    let phone: String
+    let transaction: String
+    let provider: String
+    
+    public init(channelName: String, amount: Int, email: String, phone: String, transaction: String, provider: String) {
+        self.channelName = channelName
+        self.amount = amount
+        self.email = email
+        self.phone = phone
+        self.transaction = transaction
+        self.provider = provider
+    }
+}

--- a/Sources/PaystackSDK/Core/Models/Models/MobileMoneyData.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/MobileMoneyData.swift
@@ -3,11 +3,11 @@ import Foundation
 public struct MobileMoneyData: Equatable {
     let channelName: String
     let amount: Int
-    let email : String
+    let email: String
     let phone: String
     let transaction: String
     let provider: String
-    
+
     public init(channelName: String, amount: Int, email: String, phone: String, transaction: String, provider: String) {
         self.channelName = channelName
         self.amount = amount

--- a/Sources/PaystackSDK/Core/Models/Models/VerifyAccessCode/ChannelOptions.swift
+++ b/Sources/PaystackSDK/Core/Models/Models/VerifyAccessCode/ChannelOptions.swift
@@ -5,16 +5,19 @@ public struct ChannelOptions: Codable {
     public var bankTransfer: [String]?
     public var ussd: [String]?
     public var qrCode: [String]?
+    public var mobileMoney: [MobileMoney]?
 
-    public init(bankTransfer: [String]? = nil, ussd: [String]? = nil, qrCode: [String]? = nil) {
+    public init(bankTransfer: [String]? = nil, ussd: [String]? = nil, qrCode: [String]? = nil, mobileMoney: [MobileMoney]? = nil) {
         self.bankTransfer = bankTransfer
         self.ussd = ussd
         self.qrCode = qrCode
+        self.mobileMoney = mobileMoney
     }
 
     enum CodingKeys: String, CodingKey {
         case ussd
         case qrCode = "qr"
         case bankTransfer = "bank_transfer"
+        case mobileMoney = "mobile_money"
     }
 }

--- a/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
+++ b/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length line_length
 import XCTest
 @testable import PaystackCore
 
@@ -122,4 +122,4 @@ final class ChargeTests: PSTestCase {
     }
 
 }
-// swiftlint:enable file_length type_body_length
+// swiftlint:enable file_length type_body_length line_length

--- a/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
+++ b/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length type_body_length
 import XCTest
 @testable import PaystackCore
 
@@ -121,3 +122,4 @@ final class ChargeTests: PSTestCase {
     }
 
 }
+// swiftlint:enable file_length type_body_length

--- a/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
+++ b/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
@@ -26,7 +26,7 @@ final class ChargeTests: PSTestCase {
 
         _ = try serviceUnderTest.authenticateCharge(withOtp: "12345", accessCode: "abcde").sync()
     }
-    
+
     func testMobileMoneyCharge() throws {
         let mobileMoneyRequestBody = MobileMoneyChargeRequest(channelName: "MOBILE_MONEY_1504248187", amount: 1000, email: "peter@paystack.com", phone: "0723362418", transaction: "1504248187", provider: "MPESA")
 
@@ -36,12 +36,11 @@ final class ChargeTests: PSTestCase {
             .expectHeader("Authorization", "Bearer \(apiKey)")
             .expectBody(mobileMoneyRequestBody)
             .andReturn(json: "ChargeMobileMoneyResponse")
-        
+
         let mobileMoneyData = MobileMoneyData(channelName: "MOBILE_MONEY_1504248187", amount: 1000, email: "peter@paystack.com", phone: "0723362418", transaction: "1504248187", provider: "MPESA")
 
         _ = try serviceUnderTest.chargeMobileMoney(with: mobileMoneyData).sync()
     }
-
 
     func testAuthenticateChargeWithPhoneAuthentication() throws {
         let phoneRequestBody = SubmitPhoneRequest(phone: "0111234567", accessCode: "abcde")
@@ -105,7 +104,7 @@ final class ChargeTests: PSTestCase {
 
         _ = try serviceUnderTest.listenFor3DSResponse(for: transactionId).sync()
     }
-    
+
     func testListenForMobileMoney() throws {
         let transactionId = 1234
         let mockSubscription = PusherSubscription(channelName: "MOBILE_MONEY_\(transactionId)",

--- a/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
+++ b/Tests/PaystackSDKTests/API/Charge/ChargeTests.swift
@@ -26,6 +26,22 @@ final class ChargeTests: PSTestCase {
 
         _ = try serviceUnderTest.authenticateCharge(withOtp: "12345", accessCode: "abcde").sync()
     }
+    
+    func testMobileMoneyCharge() throws {
+        let mobileMoneyRequestBody = MobileMoneyChargeRequest(channelName: "MOBILE_MONEY_1504248187", amount: 1000, email: "peter@paystack.com", phone: "0723362418", transaction: "1504248187", provider: "MPESA")
+
+        mockServiceExecutor
+            .expectURL("https://api.paystack.co/charge/mobile_money")
+            .expectMethod(.post)
+            .expectHeader("Authorization", "Bearer \(apiKey)")
+            .expectBody(mobileMoneyRequestBody)
+            .andReturn(json: "ChargeMobileMoneyResponse")
+        
+        let mobileMoneyData = MobileMoneyData(channelName: "MOBILE_MONEY_1504248187", amount: 1000, email: "peter@paystack.com", phone: "0723362418", transaction: "1504248187", provider: "MPESA")
+
+        _ = try serviceUnderTest.chargeMobileMoney(with: mobileMoneyData).sync()
+    }
+
 
     func testAuthenticateChargeWithPhoneAuthentication() throws {
         let phoneRequestBody = SubmitPhoneRequest(phone: "0111234567", accessCode: "abcde")
@@ -88,6 +104,21 @@ final class ChargeTests: PSTestCase {
             .andReturnString(responseString)
 
         _ = try serviceUnderTest.listenFor3DSResponse(for: transactionId).sync()
+    }
+    
+    func testListenForMobileMoney() throws {
+        let transactionId = 1234
+        let mockSubscription = PusherSubscription(channelName: "MOBILE_MONEY_\(transactionId)",
+                                                  eventName: "response")
+
+        // swiftlint:disable:next line_length
+        let responseString = "{\"redirecturl\":\"?trxref=2wdckavunc&reference=2wdckavunc\",\"trans\":\"1234\",\"trxref\":\"2wdckavunc\",\"reference\":\"2wdckavunc\",\"status\":\"success\",\"message\":\"Success\",\"response\":\"Approved\"}"
+
+        mockSubscriptionListener
+            .expectSubscription(mockSubscription)
+            .andReturnString(responseString)
+
+        _ = try serviceUnderTest.listenForMobileMoneyResponse(for: transactionId).sync()
     }
 
 }

--- a/Tests/PaystackSDKTests/API/Charge/Resources/ChargeMobileMoneyResponse.json
+++ b/Tests/PaystackSDKTests/API/Charge/Resources/ChargeMobileMoneyResponse.json
@@ -1,0 +1,15 @@
+{
+    "status": true,
+    "message": "Charge attempted",
+    "data": {
+        "transaction": "1504248187",
+        "phone": "0703362111",
+        "provider": "MPESA",
+        "channel_name": "MOBILE_MONEY_1504248187",
+        "display": {
+            "type": "pop",
+            "message": "Please complete authorization process on your mobile phone",
+            "timer": 60
+        }
+    }
+}

--- a/Tests/PaystackSDKTests/API/Transactions/Resources/VerifyAccessCode.json
+++ b/Tests/PaystackSDKTests/API/Transactions/Resources/VerifyAccessCode.json
@@ -15,12 +15,27 @@
       "card",
       "qr",
       "ussd",
-      "eft"
+      "eft",
+      "mobile_money"
     ],
     "channel_options": {
       "qr": [
         "visa"
       ],
+      "mobile_money": [
+                     {
+                         "key": "MPESA",
+                         "value": "M-PESA",
+                         "isNew": true,
+                         "phoneNumberRegex": "^\\+254(7([0-2]\\d|4\\d|5(7|8|9)|6(8|9)|9[0-9])|(11\\d))\\d{6}$"
+                     },
+                     {
+                         "key": "MPESA_OFF",
+                         "value": "M-PESA",
+                         "isNew": false,
+                         "phoneNumberRegex": "^\\+254(7([0-2]\\d|4\\d|5(7|8|9)|6(8|9)|9[0-9])|(11\\d))\\d{6}$"
+                     }
+                 ],
       "ussd": [
         "737",
         "822",

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
@@ -26,7 +26,7 @@ final class ChargeRepositoryImplementationTests: PSTestCase {
         let expectedResult = VerifyAccessCode(amount: 10000,
                                               currency: "NGN",
                                               accessCode: "Access_Code_Test",
-                                              paymentChannels: [.card, .qr, .ussd],
+                                              paymentChannels: [.card, .qr, .ussd,.mobileMoney],
                                               domain: .test,
                                               merchantName: "Test Merchant",
                                               publicEncryptionKey: "test_encryption_key",

--- a/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
+++ b/Tests/PaystackSDKTests/UI/Charge/ChargeRepositoryImplementationTests.swift
@@ -26,7 +26,7 @@ final class ChargeRepositoryImplementationTests: PSTestCase {
         let expectedResult = VerifyAccessCode(amount: 10000,
                                               currency: "NGN",
                                               accessCode: "Access_Code_Test",
-                                              paymentChannels: [.card, .qr, .ussd,.mobileMoney],
+                                              paymentChannels: [.card, .qr, .ussd, .mobileMoney],
                                               domain: .test,
                                               merchantName: "Test Merchant",
                                               publicEncryptionKey: "test_encryption_key",


### PR DESCRIPTION
	- Added Mobile Money as a supported channel
	- Added endpoint for Mobile Money charge
	- Added listener for mobile money events
	- Added unit tests for endpoint and listener for mobile money charge
	- Added Mock responses
	- Updated tests to support mobile money as a channel