### PR TITLE
MOB-913 Fix deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,9 @@ jobs:
         body=$(/usr/libexec/PlistBuddy -c "Print Description" ./Sources/PaystackSDK/Versioning/versions.plist)
         echo "body=${body}" >> $GITHUB_ENV
         cd  Sources/PaystackSDK/Core/Service/Subscription
-        PLIST= secrets.plist
+        PLIST=secrets.plist
         /usr/libexec/PlistBuddy -c "Set PUSHER_API_KEY $PUSH_TOKEN" $PLIST
-        cd ../../../..
+        cd ../../../../..
       env:
         PUSH_TOKEN: ${{ secrets.PUSH_TOKEN }}  
 


### PR DESCRIPTION
Syntax issue with bash local variable 
Updated the go back folder to correct location