### PR TITLE
MOB-917 Fix Pusher emitting multiple events on Closed Thread

### DIFF
--- a/Sources/PaystackSDK/Core/Service/Subscription/PusherSubscriptionListener.swift
+++ b/Sources/PaystackSDK/Core/Service/Subscription/PusherSubscriptionListener.swift
@@ -57,9 +57,13 @@ struct PusherSubscriptionListener: SubscriptionListener {
         channel.bind(eventName: eventName, eventCallback: {
             guard let stringData = $0.data else {
                 subscriptionResponse(.failure(.noData))
+                pusher.unsubscribe($0.channelName ?? "")
+                pusher.disconnect()
                 return
             }
             subscriptionResponse(.success(stringData))
+            pusher.unsubscribe($0.channelName ?? "")
+            pusher.disconnect()
         })
 
     }


### PR DESCRIPTION
	- After Pusher emits its success or failure response, subscribe from the event and close the pusher connection