### PR TITLE
MOB-936 Update Continuous and deployment Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build
-      run: swift build -v
-    - name: Run tests
+    - name: Select Xcode Version
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.3.0'
+  
+    - name: Setup environment
       run: |
-        swift test --enable-code-coverage -v
-        xcrun llvm-cov export -format="lcov" .build/debug/PaystackSDKPackageTests.xctest/Contents/MacOS/PaystackSDKPackageTests -instr-profile .build/debug/codecov/default.profdata > info.lcov
+        bundle install
+
+    - name: Build and Run tests
+      run: |
+        xcodebuild clean build test -scheme PaystackSDK-Package -sdk iphonesimulator17.4 -destination "OS=17.4,name=iPhone 15 Pro" -enableCodeCoverage YES CODE_SIGNING_REQUIRED=NO
+        brew install sonar-scanner
+        bundle exec fastlane sonar_scan
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -35,7 +43,7 @@ jobs:
     - name: setup-cocoapods
       uses: maxim-lobanov/setup-cocoapods@v1
       with:
-        version: 1.14.2
+        version: 1.15.2
     
     - name: Run pod lint for Paystack Core
       run: pod lib lint PaystackCore.podspec --allow-warnings

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         release_name: ${{ env.version }}
         body: ${{ env.body }}
 
-  Publish Cocoapods:
+  Publish_Cocoapods:
     runs-on: ubuntu-latest
     needs: deploy
     steps:
@@ -54,7 +54,7 @@ jobs:
       uses: actions/checkout@v4
 
     - uses: ruby/setup-ruby@v1
-        with:
+      with:
           ruby-version: '3.2.2'
 
     - name: Deploy to Cocoapods

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,8 +46,20 @@ jobs:
         release_name: ${{ env.version }}
         body: ${{ env.body }}
 
+  Publish Cocoapods:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+
     - name: Deploy to Cocoapods
       run: |
+        gem install cocoapods
         set -eo pipefail
         pod trunk push PaystackCore.podspec --allow-warnings
         pod trunk push PaystackUI.podspec --allow-warnings


### PR DESCRIPTION
	- Updated workflow for main branch to run with Xcodebuild instead of swift build
	- Changed the deployment of Cocoapods from MacOS to Linux and installing cocoapods on Linux machine